### PR TITLE
fix: Fixed duplicated header logo/title

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -85,7 +85,6 @@ const config = {
       },
       navbar: {
         hideOnScroll: false,
-        title: "Tigris",
         logo: {
           href: "/",
           src: "/logo/light.png",


### PR DESCRIPTION
Fixes this duplicate title on header 
<img width="134" alt="image" src="https://user-images.githubusercontent.com/917579/202277645-89a1da46-6b31-4a3f-b473-605731fc28d3.png">
