### PR TITLE
chore: make PostHog url configurable

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -70,6 +70,7 @@ const config = {
       "posthog-docusaurus",
       {
         apiKey: process.env.NEXT_POSTHOG_APIKEY,
+        appUrl: process.env.NEXT_PUBLIC_POSTHOG_HOST,
         enableInDevelopment: process.env.USE_POSTHOG_IN_DEVELOPMENT === "true",
       },
     ],


### PR DESCRIPTION
`NEXT_PUBLIC_POSTHOG_HOST` is set as a shared env var in Vercel, so when this is deployed we'll start using our proxy.