### PR TITLE
Add inline CTA for tracking conversions on promoted posts

### DIFF
--- a/blog/2024-10-02-availability/index.mdx
+++ b/blog/2024-10-02-availability/index.mdx
@@ -23,6 +23,7 @@ authors: [ks, xe]
 tags: [object storage, reliability, performance]
 ---
 
+import InlineCta from "@site/src/components/InlineCta";
 import PullQuote from "@site/src/components/PullQuote";
 
 At Tigris Data, we provide object storage to our users. People put bytes into
@@ -113,6 +114,12 @@ Under our definition, an authentication failure (401) or a file not found (404)
 is still a successful request (as the system is correctly denying access or not
 finding a file that may not exist), but an internal server error (500) would be
 a failed request and thus count against us.
+
+<InlineCta
+  title={"Want to try it out?"}
+  subtitle={"Make a global bucket with no egress fees"}
+  button={"Get Started"}
+/>
 
 ## Why these metrics matter
 

--- a/blog/2024-10-25-object-notifications/index.mdx
+++ b/blog/2024-10-25-object-notifications/index.mdx
@@ -13,6 +13,8 @@ authors: [garren]
 tags: [object storage, s3, event streaming, changes, notifications]
 ---
 
+import InlineCta from "@site/src/components/InlineCta";
+
 ![Autumn trees on a dusty road in Magoebaskloof, South Africa](./trees.jpg)
 
 <center>
@@ -74,6 +76,12 @@ To solve this, when a change is received at a region it looks at the
 `Last Modified` timestamp of the metadata to determine if the change is new and
 needs to be applied or if the region has already seen a newer change. It will
 discard the change if it is old.
+
+<InlineCta
+  title={"Want to try it out?"}
+  subtitle={"Make a global bucket with no egress fees"}
+  button={"Get Started"}
+/>
 
 ### The Object Notification Hub
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint": "^8.12.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-react": "^7.29.4",
-    "prettier": "2.6.2",
+    "prettier": "2.8.8",
     "typescript": "~5.2.2"
   },
   "engines": {

--- a/src/components/InlineCta.js
+++ b/src/components/InlineCta.js
@@ -1,0 +1,49 @@
+import tigrisConfig from "@site/tigris.config.js";
+import React from "react";
+import PropTypes from "prop-types";
+
+function InlineCta(props) {
+  return (
+    <div>
+      <div>
+        <div className="is--color_gradient_back">
+          <div className="sl_card_m-2 card_static cta-flex">
+            <div className="cta-margin-left">
+              <h1 className="sl_title_m fix-1px">{props.title}</h1>
+              <p>{props.subtitle}</p>
+            </div>
+            <div className="cta-flex-item cta-margin-right">
+              <div style={{ "white-space": "nowrap" }}>
+                <a href={tigrisConfig.getStartedUrl} className="cta-link">
+                  <div>
+                    {props.button}
+                    <svg
+                      width="13.5"
+                      height="13.5"
+                      aria-hidden="true"
+                      viewBox="0 0 24 24"
+                      className="iconExternalLink_node_modules-@docusaurus-theme-classNameic-lib-theme-Icon-ExternalLink-styles-module"
+                    >
+                      <path
+                        fill="currentColor"
+                        d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"
+                      ></path>
+                    </svg>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+InlineCta.propTypes = {
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
+  button: PropTypes.string,
+};
+
+export default InlineCta;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -670,3 +670,529 @@ table td {
 .disable-external-icon svg {
   display: none;
 }
+
+/* Copy Styling from the Webflow site */
+.is--color_gradient_back {
+  -webkit-text-fill-color: inherit;
+  background-image: linear-gradient(90deg, #62feb5, #6cd3f5 44%, #836af7c9);
+  background-clip: padding-box;
+  border-radius: 24px;
+  width: 100%;
+  padding: 1px;
+}
+
+.is--color_gradient_back-2 {
+  -webkit-text-fill-color: inherit;
+  background-image: linear-gradient(90deg, #62feb5, #6cd3f5 44%, #836af7c9);
+  background-clip: padding-box;
+  border-radius: 24px;
+  width: 100%;
+  min-width: 420px;
+  padding: 1px;
+}
+
+.sl_image--r-card-m {
+  border: 1px solid var(--token--border-1);
+  object-fit: contain;
+  width: 100%;
+  height: auto;
+}
+
+.sl_image--r-card-m {
+  border: 1px solid var(--token--border-1);
+  object-fit: contain;
+  width: 100%;
+  height: auto;
+}
+
+.sl_image--r-card-m.is--ratio_1_1 {
+  aspect-ratio: 1;
+}
+
+.sl_card_m-2 {
+  background-color: #142229;
+  border: 1px solid #fff0;
+  border-radius: 24px;
+}
+
+.sl_card_m-2.card_static {
+  grid-column-gap: 20px;
+  grid-row-gap: 0px;
+  width: 100%;
+  padding-left: 36px;
+  padding-right: 36px;
+  display: flex;
+}
+
+.cta-link {
+  font-weight: 500;
+  font-variation-settings: "wght" 500;
+  padding: 0.7rem 1rem;
+  display: flex;
+  background-color: var(--docs-color-primary);
+  border-radius: 4px;
+  transition-property: all;
+  --ifm-link-hover-color: #fff;
+  --ifm-navbar-link-hover-color: #fff;
+  color: #000000;
+}
+
+.sl_cta_primary {
+  grid-column-gap: 0.5rem;
+  grid-row-gap: 0.5rem;
+  background-color: var(--docs-color-primary);
+  box-shadow: 0 0 0 1px #fff0;
+  color: #050c0f;
+  text-align: center;
+  justify-content: center;
+  align-items: center;
+  transition: background-color 0.35s;
+  display: flex;
+}
+
+.sl_cta_primary:hover {
+  background-color: var(--token--cta-1-bg-hover);
+  color: var(--token--cta-1-text);
+}
+
+.blockquote {
+  border-left: 5px solid #e2e2e2;
+  margin-bottom: 10px;
+  padding: 10px 20px;
+  font-size: 18px;
+  line-height: 22px;
+}
+
+.cta-flex {
+  display: flex;
+  flex-wrap: wrap;
+  padding-top: 21px;
+  padding-bottom: 21px;
+}
+
+.cta-flex-item {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.cta-margin-right {
+  justify-self: flex-start;
+  justify-content: flex-end;
+  align-items: center;
+  position: relative;
+}
+
+.cta-margin-left {
+  justify-content: space-between;
+  flex-grow: 1;
+  align-items: center;
+  position: relative;
+}
+
+.sl_page_wrap {
+  max-width: 100vw;
+}
+
+.sl_page_main.color-dark {
+  background-image: linear-gradient(
+    to bottom,
+    var(--brand-2--1400),
+    var(--brand-2--1400)
+  );
+  position: relative;
+}
+
+.sl_section {
+  background-color: var(--token--surface-1);
+  position: relative;
+}
+
+.sl_section.color-trans {
+  background-color: #0b181e00;
+}
+
+.sl_section_padding {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.sl_spacer {
+  padding-right: 0;
+}
+
+.sl_container {
+  width: 100%;
+  max-width: 78rem;
+}
+
+.styleguide_grid {
+  grid-column-gap: 2rem;
+  grid-row-gap: 2rem;
+  grid-template-rows: auto;
+  grid-template-columns: 1fr;
+  grid-auto-columns: 1fr;
+  place-items: start;
+  display: grid;
+}
+
+.sl_title_xl {
+  color: var(--token--text-1);
+  font-family: Geist, sans-serif;
+  font-weight: 600;
+}
+
+.sl_title_l,
+.sl_title_m {
+  color: var(--token--text-1);
+}
+
+.sl_title_m.fix-1px {
+  margin-bottom: -1px;
+  line-height: 1.2;
+  font-family: var(--font-family--ff1);
+  font-weight: 600;
+  font-variation-settings: "wght" 600;
+  box-sizing: border-box;
+  font-size: 1.75rem;
+}
+
+.sl_title_s {
+  color: var(--token--text-1);
+}
+
+.sl_body_l_1,
+.sl_body_m_1,
+.sl_body_s_1,
+.sl_body_xs_1,
+.sl_body_l_2,
+.sl_body_m_2,
+.sl_body_s_2,
+.sl_body_xs_2 {
+  color: var(--token--text-2);
+}
+
+.sl_label_m,
+.sl_label_s {
+  color: var(--token--accent-2);
+}
+
+.sl_link_m,
+.sl_link_s {
+  transition: color 0.25s;
+}
+
+.sl_cta_primary {
+  grid-column-gap: 0.5rem;
+  grid-row-gap: 0.5rem;
+  background-color: var(--token--cta-1-bg);
+  box-shadow: 0 0 0 1px var(--token--cta-1-border);
+  color: var(--token--cta-1-text);
+  text-align: center;
+  justify-content: center;
+  align-items: center;
+  transition: background-color 0.35s;
+  display: flex;
+}
+
+.sl_cta_primary:hover {
+  background-color: var(--token--cta-1-bg-hover);
+  color: var(--token--cta-1-text);
+}
+
+.sl_cta_secondary {
+  grid-column-gap: 0.5rem;
+  grid-row-gap: 0.5rem;
+  background-color: var(--token--cta-2-bg);
+  box-shadow: 0 0 0 1px var(--token--cta-2-border);
+  color: var(--token--cta-2-text);
+  text-align: center;
+  justify-content: center;
+  align-items: center;
+  transition: background-color 0.35s;
+  display: flex;
+}
+
+.sl_cta_secondary:hover {
+  background-color: var(--token--cta-2-bg-hover);
+  color: var(--token--cta-2-text);
+}
+
+.sl_cta_tertiary {
+  z-index: 100;
+  grid-column-gap: 0.5rem;
+  grid-row-gap: 0.5rem;
+  color: var(--token--text-1);
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  position: relative;
+}
+
+.sl_cta_tertiary:hover {
+  color: var(--white);
+}
+
+.sl_layout_12cols----gap-el-l {
+  grid-column-gap: 2.5rem;
+  grid-template-rows: auto;
+  grid-template-columns:
+    minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr)
+    minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(
+      0,
+      1fr
+    )
+    minmax(0, 1fr) minmax(0, 1fr);
+  grid-auto-columns: 1fr;
+  width: 100%;
+  display: grid;
+}
+
+.sl_layout_12cols----gap-el-l.flip {
+  grid-column-gap: 2rem;
+  grid-template-columns: 1fr 1fr 1fr minmax(20px, 0.5fr) 1fr 1fr 1fr;
+  justify-content: space-between;
+}
+
+.sl_layout_row {
+  z-index: 10;
+  width: 100%;
+  position: relative;
+}
+
+.sl_layout_row.is--hidden-tablet {
+  justify-content: flex-end;
+  align-items: flex-start;
+  display: flex;
+}
+
+.styleguide_grid_element {
+  background-color: var(--token--accent-1);
+  width: 100%;
+  height: 16rem;
+}
+
+.sl_flex_dvct {
+  text-align: center;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  display: flex;
+}
+
+.sl_flex_dvlc {
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  height: 100%;
+  display: flex;
+}
+
+.sl_icn_m {
+  color: var(--token--text-1);
+  flex: none;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.sl_cta_icn {
+  flex: none;
+  justify-content: center;
+  align-items: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  transition: transform 0.25s;
+  display: flex;
+}
+
+.sl_icn_l,
+.sl_icn_s,
+.sl_icn_xs {
+  color: var(--token--text-1);
+  flex: none;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.sl_icn_l--c-ac1,
+.sl_icn_m--c-ac1,
+.sl_icn_s--c-ac1,
+.sl_icn_xs--c-ac1,
+.sl_icn_l--c-ac2,
+.sl_icn_m--c-ac2,
+.sl_icn_s--c-ac2,
+.sl_icn_xs--c-ac2 {
+  flex: none;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.sl_pill_s,
+.sl_pill_m {
+  grid-column-gap: 0.375rem;
+  border: 1px solid var(--token--border-1);
+  background-color: var(--token--surface-1);
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.sl_tab_link {
+  border: 1px solid var(--token--border-1);
+  background-color: var(--token--surface-1);
+  color: var(--token--text-2);
+  flex: none;
+}
+
+.sl_tab_link:hover {
+  color: var(--token--text-2);
+}
+
+.sl_tab_link.w--current {
+  background-color: var(--token--surface-3);
+  color: var(--token--text-1);
+}
+
+.sl_input {
+  border: 1px solid var(--token--cta-2-border);
+  background-color: var(--token--surface-1);
+}
+
+.sl_wrap_icon {
+  background-color: var(--token--surface-3);
+  flex: none;
+}
+
+.sl_card_s,
+.sl_card_m,
+.sl_card_l {
+  border: 1px solid var(--token--border-2);
+  background-color: var(--token--surface-2);
+}
+
+.sl_card_l.gradient_back-green {
+  pointer-events: auto;
+}
+
+.styleguide_grid_4cols {
+  grid-column-gap: 2rem;
+  grid-row-gap: 2rem;
+  grid-template-rows: auto;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-auto-columns: 1fr;
+  width: 100%;
+  display: grid;
+}
+
+.styleguide_grid_4cols--column {
+  grid-column-gap: 2rem;
+  grid-row-gap: 2rem;
+  flex-direction: column;
+  display: flex;
+}
+
+.sl_body_l_1--c-txt1,
+.sl_body_m_1--c-txt1,
+.sl_body_s_1--c-txt1,
+.sl_body_xs_1--c-txt1,
+.sl_body_l_2--c-txt1,
+.sl_body_m_2--c-txt1,
+.sl_body_s_2--c-txt1,
+.sl_body_xs_2--c-txt1 {
+  color: var(--token--text-2);
+}
+
+.sl_flex_dvct_mvlt {
+  text-align: center;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  display: flex;
+}
+
+.sl_list_item {
+  grid-column-gap: 0.75rem;
+  grid-row-gap: 0.75rem;
+  align-items: flex-start;
+  display: flex;
+}
+
+.sl_flex_dvlt {
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  height: 100%;
+  display: flex;
+}
+
+.sl_faq_item {
+  cursor: pointer;
+  width: 100%;
+}
+
+.sl_faq_item--wrap_answer {
+  overflow: hidden;
+}
+
+.sl_faq_item--icn {
+  color: var(--token--text-1);
+  flex: none;
+  justify-content: center;
+  align-items: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-top: 1px;
+  transition: transform 0.25s;
+  display: flex;
+}
+
+.sl_faq_item--question {
+  grid-column-gap: 1rem;
+  grid-row-gap: 1rem;
+  justify-content: space-between;
+  align-items: flex-start;
+  display: flex;
+}
+
+.sl_cta_icon_primary {
+  grid-column-gap: 0.5rem;
+  grid-row-gap: 0.5rem;
+  background-color: var(--token--cta-1-bg);
+  box-shadow: 0 0 0 1px var(--token--cta-1-border);
+  color: var(--token--cta-1-text);
+  justify-content: center;
+  align-items: center;
+  padding: 0.5rem;
+  transition: background-color 0.35s;
+  display: flex;
+}
+
+.sl_cta_icon_primary:hover {
+  background-color: var(--token--cta-1-bg-hover);
+  color: var(--token--cta-1-text);
+}
+
+.sl_cta_icon_secondary {
+  grid-column-gap: 0.5rem;
+  grid-row-gap: 0.5rem;
+  background-color: var(--token--cta-2-bg);
+  box-shadow: 0 0 0 1px var(--token--cta-2-border);
+  color: var(--token--cta-2-text);
+  justify-content: center;
+  align-items: center;
+  padding: 0.5rem;
+  transition: background-color 0.35s;
+  display: flex;
+}
+
+.sl_cta_icon_secondary:hover {
+  background-color: var(--token--cta-2-bg-hover);
+  color: var(--token--cta-2-text);
+}
+
+.sl_label_m--c-txt1,
+.sl_label_s--c-txt1 {
+  color: var(--token--accent-2);
+}

--- a/tigris.config.js
+++ b/tigris.config.js
@@ -8,4 +8,5 @@ module.exports = {
   discordUrl: "https://www.tigrisdata.com/discord/",
   docsUrl: "https://www.tigrisdata.com/docs",
   statusPageUrl: "https://status.tigris.dev/",
+  getStartedUrl: "https://www.tigrisdata.com/docs/get-started/",
 };


### PR DESCRIPTION
Adds an inline mdx component with a responsive CTA block that links to the Get Started docs page. The title, subtitle, and button text are all configurable so it can be customized to the post.