### PR TITLE
add HeroImage component

### DIFF
--- a/src/components/HeroImage/index.tsx
+++ b/src/components/HeroImage/index.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from "react";
+import styles from "./styles.module.css";
+
+export interface HeroImageProps {
+  alt: string;
+  file: string;
+  hdrFile?: string;
+}
+
+export default function HeroImage({ alt, file, hdrFile }: HeroImageProps) {
+  const [src, setSrc] = useState(file);
+
+  useEffect(() => {
+    if (hdrFile && window.matchMedia("(dynamic-range: high)").matches) {
+      setSrc(hdrFile);
+    }
+  }, [hdrFile]);
+
+  return (
+    <figure className={styles.figure}>
+      <img alt={alt} className={styles.heroImage} src={src} loading="lazy" />
+      {alt && <figcaption className={styles.caption}>{alt}</figcaption>}
+    </figure>
+  );
+}

--- a/src/components/HeroImage/styles.module.css
+++ b/src/components/HeroImage/styles.module.css
@@ -1,0 +1,26 @@
+.figure {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+
+.heroImage {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 100%;
+  height: auto;
+}
+
+.caption {
+  margin: 0.25rem 0.5rem;
+  text-align: center;
+  color: #4b5563;
+}
+
+@media (prefers-color-scheme: dark) {
+  .caption {
+    color: #9ca3af;
+  }
+}


### PR DESCRIPTION
I've been copying the markup between posts for a while and I want to make this a generic component. The hdrImage is a mistake, it's an absolute catastrophe and I want to see if it causes more engagement with the posts.

Automated projection from SDR to HDR is a very hit or miss affair. Most of the time, it will miss. Sometimes however, it will work fairly well. Well enough that it's worth experimenting with people's retinas in order to see how bad of an idea this actually is.

Science is not about "why". It's about "why not?"