### PR TITLE
Fix: Standardize blog content width and component layouts

### DIFF
--- a/blog/2025-04-28-mcp-sharing/index.mdx
+++ b/blog/2025-04-28-mcp-sharing/index.mdx
@@ -306,7 +306,7 @@ tool:
   </TabItem>
 </Tabs>
 
-To make sure it’s available, ask your editor what Tigris tools it has available:
+To make sure it's available, ask your editor what Tigris tools it has available:
 
 <KS top>
 Do you have a Tigris tool for uploading a file and getting a public URL?

--- a/blog/2025-08-07-qwen-image/index.mdx
+++ b/blog/2025-08-07-qwen-image/index.mdx
@@ -27,59 +27,9 @@ tags:
 ---
 
 import InlineCta from "@site/src/components/InlineCta";
-
-<style>
-  {`@media (min-width: 1536px) {
-  img:not(.hero-image) {
-    max-width: 48rem; /* 3xl equivalent */
-  }
-}
-
-.hero-image {
-  margin-bottom: 1rem;
-}
-
-p:not(:has(img)) {
-  max-width: 42rem; /* 2xl equivalent */
-  margin-left: auto;
-  margin-right: auto;
-}
-
-h2, h3, h4, h5, h6, blockquote, .theme-admonition {
-  max-width: 42rem; 
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.theme-code-block {
-  max-width: 48rem; /* 3xl equivalent */
-  margin-left: auto;
-  margin-right: auto;
-}
-
-table {
-  max-width: 42rem; /* 4xl equivalent - wider for tables */
-  margin-left: auto;
-  margin-right: auto;
-  width: 100%;
-  border-collapse: collapse;
-}
-
-td, th {
-  padding: 0.75rem;
-  text-align: left;
-}
-
-img:not(.hero-image) {
-  margin-left: auto;
-  margin-right: auto;
-  display: block;
-}`}
-</style>
-
 import heroimage from "./ty-vs-ty.webp";
 
-<img src={heroimage} class="hero-image" />
+<img src={heroimage} alt="Ty vs Ty comparison" />
 
 This week Alibaba released
 [Qwen Image](https://qwenlm.github.io/blog/qwen-image/), an open-weights
@@ -158,10 +108,14 @@ more noise with each diffusion step. It's synthesizing an image from scratch by
 removing all of the noise until the image remains, organizing the chaos into
 whatever you asked it to generate.
 
-I think this is much easier to explain visually, so here’s an animation of each
+I think this is much easier to explain visually, so here's an animation of each
 diffusion phase of Qwen Image generating Ty riding a skateboard:
 
-<center style={{ marginBottom: "2rem" }}>![](./ty-diffusion.webp)</center>
+<div className="indented-image">
+
+![Ty diffusion animation showing each de-noising step](./ty-diffusion.webp)
+
+</div>
 
 Each frame in that GIF shows a separate de-noising step. You can see the noise
 gradually get removed as the image is unearthed from the chaos. I don’t really
@@ -196,7 +150,7 @@ paragraph-level semantics, and fine-grained details.” In the paper, they compa
 the generation of text in a flat document, but how does it fare in more complex
 scenarios?
 
-![](./text-clarity.webp)
+![Figure 17 from the Qwen Image paper showing text rendering capabilities](./text-clarity.webp)
 
 _Figure 17 from the
 [Qwen Image paper](https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-Image/Qwen_Image.pdf)

--- a/src/components/PostEmbed/styles.module.css
+++ b/src/components/PostEmbed/styles.module.css
@@ -4,49 +4,82 @@
   padding: 16px;
   color: oklch(98.4% 0.003 247.858);
   font-family: system-ui, sans-serif;
-  max-width: 600px;
-  width: 100%;
-  margin: 0 auto; /* center horizontally */
+  max-width: calc(42rem - 6rem); /* Indented from content width */
+  width: calc(100% - 6rem);
+  margin: 2rem auto; /* Add vertical spacing and center horizontally */
+  display: block;
 }
 
 .header {
   display: flex;
+  flex-direction: row;
   align-items: center;
+  justify-content: flex-start;
+  width: 100%;
+  margin: 0;
+  padding: 0;
 }
 
 .avatar {
   width: 48px;
   height: 48px;
+  min-width: 48px;
+  min-height: 48px;
+  max-width: 48px;
+  max-height: 48px;
   border-radius: 50%;
-  margin-right: 12px;
+  margin: 0 8px 0 0;
+  padding: 0;
+  flex-shrink: 0;
+  flex-grow: 0;
+  display: block;
+  object-fit: cover;
 }
 
 .userInfo {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  margin: 0;
+  padding: 0 0 0 4px;
+  flex-grow: 1;
+  width: auto;
 }
 
 .username {
   font-weight: 600;
   font-size: 16px;
   line-height: 1.2;
+  text-align: left;
+  margin: 0;
+  padding: 0;
+  display: block;
+  width: 100%;
 }
 
 .userId {
   color: oklch(86.9% 0.022 252.894); /* slate‑300 */
   font-size: 14px;
   line-height: 1.2;
+  text-align: left;
+  margin: 2px 0 0 0;
+  padding: 0;
+  display: block;
+  width: 100%;
 }
 
 .content {
   margin: 12px 0;
   font-size: 16px;
   line-height: 1.5;
+  text-align: left;
 }
 
 .timestamp {
   font-size: 14px;
   color: oklch(86.9% 0.022 252.894); /* slate‑700 */
+  text-align: left;
 }
 
 .divider {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1209,3 +1209,258 @@ table td {
 .theme-code-block code {
   max-width: 360px;
 }
+
+/* Blog Content Width Constraints */
+/* Apply consistent max-width to all blog content elements for optimal readability */
+:root {
+  --blog-content-max-width: 42rem; /* ~672px - optimal reading width */
+}
+
+/* Target blog post content using Docusaurus's actual markdown container */
+/* Using the .markdown class that Docusaurus applies to blog content */
+.markdown > p,
+.markdown > ul,
+.markdown > ol,
+.markdown > h1,
+.markdown > h2,
+.markdown > h3,
+.markdown > h4,
+.markdown > h5,
+.markdown > h6,
+.markdown > blockquote,
+.markdown > table,
+.markdown > div,
+.markdown > pre {
+  max-width: var(--blog-content-max-width);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Images - constrain to same width as text */
+/* Only target direct markdown-generated images, not images inside components */
+.markdown > p > img:not([class]),
+.markdown > p:not([class]) > img,
+.markdown > figure > img,
+.markdown > div:not([class]) > img {
+  max-width: var(--blog-content-max-width);
+  width: 100%;
+  height: auto;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+
+/* Direct markdown images that are immediate children */
+.markdown > img:not([class]) {
+  max-width: var(--blog-content-max-width);
+  width: 100%;
+  height: auto;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+
+/* Videos and other media - constrain to same width as text */
+.markdown video,
+.markdown iframe,
+.markdown embed,
+.markdown object {
+  max-width: var(--blog-content-max-width);
+  width: 100%;
+  height: auto;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+
+/* Preserve aspect ratio for iframes (e.g., YouTube embeds) */
+.markdown iframe[src*="youtube"],
+.markdown iframe[src*="vimeo"] {
+  aspect-ratio: 16 / 9;
+  height: auto;
+}
+
+/* Indented images - smaller width with extra margin */
+.markdown .indented-image {
+  max-width: var(--blog-content-max-width);
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 3rem;
+  padding-right: 3rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.markdown .indented-image img {
+  max-width: 100%;
+  width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}
+
+/* Code blocks - same width as text content */
+.markdown .theme-code-block,
+.markdown pre {
+  max-width: var(--blog-content-max-width);
+  margin-left: auto;
+  margin-right: auto;
+  overflow-x: auto; /* Allow horizontal scrolling for wide code */
+}
+
+/* Mermaid diagrams - constrain width and their containers */
+.markdown .mermaid,
+.markdown [class*="mermaid"],
+.markdown svg[id^="mermaid"],
+.markdown > div:has(.mermaid),
+.markdown > div:has(svg[id^="mermaid"]) {
+  max-width: var(--blog-content-max-width) !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  overflow-x: auto;
+  display: block;
+}
+
+/* Ensure mermaid SVGs themselves are constrained */
+.markdown .mermaid svg,
+.markdown div[class*="mermaid"] svg {
+  max-width: 100% !important;
+  height: auto !important;
+}
+
+/* Center elements (like image captions) should also be constrained */
+.markdown center {
+  max-width: var(--blog-content-max-width);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Admonitions (:::note, :::warning, etc.) */
+.markdown .admonition,
+.markdown .theme-admonition,
+.markdown [class*="admonition"] {
+  max-width: var(--blog-content-max-width);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Lists inside other elements should also be constrained */
+.markdown li > p,
+.markdown li > ul,
+.markdown li > ol {
+  max-width: none; /* Don't double-constrain nested elements */
+}
+
+/* Custom components that might be used in blog posts */
+.markdown [class*="Carousel"],
+.markdown [class*="PullQuote"],
+.markdown [class*="Reasoning"],
+.markdown [class*="ErrorSquiggle"],
+.markdown [class*="MCPCall"],
+.markdown [class*="MCPFileList"],
+.markdown [class*="NewsletterSubscribe"],
+.markdown [class*="PostEmbed"],
+.markdown [class*="TerminalWindow"] {
+  max-width: var(--blog-content-max-width);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Conv component - override the 80ch max-width from Conv/styles.module.css */
+/* Be very specific to only target Conv containers, not PostEmbed */
+.markdown
+  div[class*="container_"][class*="containerTop_"]:not([class*="PostEmbed"]),
+.markdown
+  div[class*="container_"][class*="containerBottom_"]:not(
+    [class*="PostEmbed"]
+  ) {
+  max-width: var(--blog-content-max-width) !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  /* Preserve the flex layout */
+  display: flex !important;
+  gap: 1rem !important;
+  align-items: flex-start !important;
+}
+
+/* Ensure Conv component's avatar container doesn't shrink */
+.markdown
+  div[class*="container_"][class*="containerTop_"]
+  > div[class*="avatarContainer"],
+.markdown
+  div[class*="container_"][class*="containerBottom_"]
+  > div[class*="avatarContainer"] {
+  flex-shrink: 0;
+  width: 50px;
+  height: 50px;
+}
+
+/* Ensure Conv component's content area takes remaining space */
+.markdown
+  div[class*="container_"][class*="containerTop_"]
+  > div[class*="content"],
+.markdown
+  div[class*="container_"][class*="containerBottom_"]
+  > div[class*="content"] {
+  flex: 1;
+  min-width: 0;
+  text-align: left !important;
+}
+
+/* Special handling for InlineCta with gradient background */
+.markdown .is--color_gradient_back {
+  max-width: var(--blog-content-max-width);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Ensure InlineCta component is also constrained */
+.markdown [class*="InlineCta"] {
+  max-width: var(--blog-content-max-width);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* PostEmbed components handle their own width and indentation */
+/* Ensure PostEmbed avatars remain circular - be specific to PostEmbed only */
+.markdown div[class*="PostEmbed"] img[class*="avatar"],
+.markdown
+  div[class*="container_"]:not([class*="containerTop_"]):not(
+    [class*="containerBottom_"]
+  )
+  img[class*="avatar_"] {
+  border-radius: 50%;
+  width: 48px;
+  height: 48px;
+  max-width: 48px;
+  max-height: 48px;
+  margin: 0 8px 0 0;
+  display: block;
+  object-fit: cover;
+}
+
+/* Tables - ensure they don't overflow */
+.markdown table {
+  width: 100%;
+  overflow-x: auto;
+  display: block;
+}
+
+/* Details/Summary elements */
+.markdown details {
+  max-width: var(--blog-content-max-width);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Ensure proper responsive behavior */
+@media (max-width: 768px) {
+  :root {
+    --blog-content-max-width: 100%; /* Full width on mobile */
+  }
+
+  .markdown {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Implemented consistent 42rem max-width for all blog content elements
- Fixed layout issues with Conv and PostEmbed components
- Added reusable indented image styling

## Changes Made

### Content Width Standardization
- Set uniform `--blog-content-max-width: 42rem` (~672px) for optimal readability
- Applied consistent max-width to all markdown elements:
  - Text (paragraphs, headings, lists, blockquotes)
  - Images (with special handling for component images)
  - Code blocks
  - Videos and embedded media
  - Admonitions and custom components

### Component Fixes
1. **Conv Component (Conversation bubbles)**
   - Fixed text alignment issues where content was pushed to the right
   - Preserved flexbox layout with proper avatar/content spacing
   - Override default 80ch max-width from component styles

2. **PostEmbed Component (Tweet quotes)**
   - Fixed avatar display (now properly circular at 48px)
   - Corrected name/@handle vertical stacking and left alignment
   - Set proper indentation and spacing (8px between avatar and text)

3. **InlineCta Component**
   - Constrained gradient background to content width

### New Features
- Added `.indented-image` class for images that need extra padding
- Images can be indented 3rem on each side by wrapping in `<div className="indented-image">`

### Code Quality
- Removed inline `<style>` tags from blog posts
- Deleted unused `image-max-width.css` file
- All changes formatted with Prettier
- Followed Docusaurus best practices and avoided PR #251 mistakes

## Test Plan
- [x] Verified all blog posts display with consistent content width
- [x] Tested Conv components in MCP post - text properly aligned
- [x] Checked PostEmbed components - avatars circular, spacing correct
- [x] Confirmed indented images work in Qwen post
- [x] Tested responsive behavior on mobile viewport
- [x] Ensured no visual regressions in other blog posts

🤖 Generated with [Claude Code](https://claude.ai/code)