### PR TITLE
fix(blog): align code block width with post text body

### DIFF
--- a/blog/2025-08-12-generative-software/index.mdx
+++ b/blog/2025-08-12-generative-software/index.mdx
@@ -54,7 +54,7 @@ h2, h3, h4, h5, h6, blockquote, .theme-admonition, ul, ol {
 }
 
 .theme-code-block {
-  max-width: 48rem; /* 3xl equivalent */
+  max-width: 42rem; /* 2xl equivalent */
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
Code blocks in the generative-software post were wider than the text body due to a CSS rule setting max-width to 48rem instead of 42rem. This change aligns them with the text content width.

Change-assisted-by: Qwen 3 Coder
Co-authored-by: Qwen-Coder <qwen-coder@alibabacloud.com>

<img width="762" height="395" alt="Screenshot 2025-08-12 at 12 43 57" src="https://github.com/user-attachments/assets/3f2c52b8-9c77-46db-b63c-08da42aa99cb" />
