### PR TITLE
fix: update status page url

### DIFF
--- a/blog/2025-02-19-virtual-hosted-urls/index.mdx
+++ b/blog/2025-02-19-virtual-hosted-urls/index.mdx
@@ -49,7 +49,7 @@ scalability.
 ## Why make this change now?
 
 Recently some ISPs blocked the Tigris subdomain after
-[malicious content was briefly shared](https://status.tigris.dev/incidents/01JKCBMAVT1W09PGVEAB4XCWMZ)
+[malicious content was briefly shared](https://status.tigrisdata.com/incidents/01JKCBMAVT1W09PGVEAB4XCWMZ)
 using our platform. Though we removed the malicious content, the subdomain was
 the common denominator across several reports and added to blocklist maintained
 by security vendors. This block of our domain resulted in failed downloads on

--- a/tigris.config.js
+++ b/tigris.config.js
@@ -8,7 +8,7 @@ module.exports = {
   websiteUrl: "https://www.tigrisdata.com",
   discordUrl: "https://community.tigrisdata.com/",
   docsUrl: "https://www.tigrisdata.com/docs",
-  statusPageUrl: "https://status.tigris.dev/",
+  statusPageUrl: "https://status.tigrisdata.com/",
   getStartedUrl: "https://www.tigrisdata.com/docs/get-started/",
   reportAbuseUrl: "mailto:abuse@tigrisdata.com",
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: updates hardcoded status page links from `status.tigris.dev` to `status.tigrisdata.com` in config and a blog post, with no behavior changes beyond link destinations.
> 
> **Overview**
> Updates references to the status page domain from `https://status.tigris.dev` to `https://status.tigrisdata.com`.
> 
> This changes `statusPageUrl` in `tigris.config.js` and fixes the incident link in the “Virtual Hosted URLs” blog post so both point at the new status domain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 214ae30bc3bfe1e681984f6fabcf5b0c358135cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->