### PR TITLE
Scope tigrisfiles.io post to public access only

### DIFF
--- a/blog/2026-04-02-public-bucket-domains/_social.md
+++ b/blog/2026-04-02-public-bucket-domains/_social.md
@@ -1,8 +1,8 @@
 ## LinkedIn
 
-New Tigris accounts now serve public content from a dedicated domain: **tigrisfiles.io**.
+New Tigris accounts now serve public content from a dedicated domain: **t3.tigrisfiles.io**.
 
-If you're signing up today, your public buckets and public objects are served from `tigrisfiles.io` automatically. All authenticated operations (uploads, SDK calls, CLI) continue to use `t3.storage.dev` — the only thing that changes is the URL you share for public access.
+If you're signing up today, your public buckets and public objects are served from `t3.tigrisfiles.io` automatically. All authenticated operations (uploads, SDK calls, CLI) continue to use `t3.storage.dev` — the only thing that changes is the URL you share for public access.
 
 A few things to know:
 - Existing accounts are unaffected; your current URLs keep working
@@ -16,7 +16,7 @@ Full details: https://www.tigrisdata.com/blog/public-bucket-domains
 
 ## Twitter/X
 
-New Tigris accounts now serve public content from a dedicated domain: **tigrisfiles.io**
+New Tigris accounts now serve public content from a dedicated domain: **t3.tigrisfiles.io**
 
 All authenticated access (SDK, CLI, API) still uses t3.storage.dev. Only the public URL you share with visitors changes.
 

--- a/blog/2026-04-02-public-bucket-domains/_social.md
+++ b/blog/2026-04-02-public-bucket-domains/_social.md
@@ -2,10 +2,9 @@
 
 New Tigris accounts now serve public content from a dedicated domain: **tigrisfiles.io**.
 
-This separates public content delivery from API infrastructure. If you're signing up today, your public buckets and public objects are served from `tigrisfiles.io` automatically.
+If you're signing up today, your public buckets and public objects are served from `tigrisfiles.io` automatically. All authenticated operations (uploads, SDK calls, CLI) continue to use `t3.storage.dev` — the only thing that changes is the URL you share for public access.
 
 A few things to know:
-- `tigrisfiles.io` works as a full API endpoint too — use it for everything if you prefer a single domain
 - Existing accounts are unaffected; your current URLs keep working
 - For production public content, we recommend setting up a custom domain
 
@@ -19,11 +18,9 @@ Full details: https://www.tigrisdata.com/blog/public-bucket-domains
 
 New Tigris accounts now serve public content from a dedicated domain: **tigrisfiles.io**
 
-It works as a full API endpoint too — one domain for everything.
+All authenticated access (SDK, CLI, API) still uses t3.storage.dev. Only the public URL you share with visitors changes.
 
 Existing accounts: nothing changes, your URLs keep working.
-
-For production, we recommend a custom domain for full control.
 
 Details: https://www.tigrisdata.com/blog/public-bucket-domains
 

--- a/blog/2026-04-02-public-bucket-domains/index.mdx
+++ b/blog/2026-04-02-public-bucket-domains/index.mdx
@@ -48,8 +48,11 @@ https://my-assets.t3.tigrisfiles.io/logo.png
 
 No additional configuration required.
 
-This change applies only to public anonymous access. Private access through the
-CLI, SDKs, and the S3 API continues to use `t3.storage.dev` as before.
+This change only affects how public content is served to anonymous visitors. All
+authenticated operations — uploading, listing, deleting, and managing objects
+through the CLI, SDKs, or S3 API — continue to use `t3.storage.dev`. When you
+use an SDK, every request is authenticated, whether the bucket is public or
+private. The only thing that changes is the URL you hand out for public access.
 
 Presigned URLs generated through the Tigris Console now use `tigrisfiles.io`
 automatically. Presigned URLs you generate in your own code continue to work on

--- a/blog/2026-04-02-public-bucket-domains/index.mdx
+++ b/blog/2026-04-02-public-bucket-domains/index.mdx
@@ -48,17 +48,8 @@ https://my-assets.t3.tigrisfiles.io/logo.png
 
 No additional configuration required.
 
-## Does this affect the API?
-
-`tigrisfiles.io` is fully equivalent to `t3.storage.dev`. You can use it as your
-endpoint for API calls, the AWS CLI, SDKs, and public content:
-
-```bash
-aws s3api list-buckets --endpoint-url https://t3.tigrisfiles.io
-```
-
-New accounts must use `tigrisfiles.io` to serve public content. This restriction
-applies whether you access it through a browser, API, CLI, or SDK.
+This change applies only to public anonymous access. Private access through the
+CLI, SDKs, and the S3 API continues to use `t3.storage.dev` as before.
 
 Presigned URLs generated through the Tigris Console now use `tigrisfiles.io`
 automatically. Presigned URLs you generate in your own code continue to work on

--- a/blog/2026-04-02-public-bucket-domains/index.mdx
+++ b/blog/2026-04-02-public-bucket-domains/index.mdx
@@ -40,13 +40,22 @@ New Tigris accounts serve public content — both
 [public objects in private buckets](https://www.tigrisdata.com/docs/objects/public-objects/)
 — from `t3.tigrisfiles.io` instead of `t3.storage.dev`.
 
-Public content URLs use the bucket name as a subdomain:
+Public content is available on three dedicated domains, all serving the same
+content:
 
-```
-https://my-assets.t3.tigrisfiles.io/logo.png
-```
+| Domain                      | Example URL                                     |
+| --------------------------- | ----------------------------------------------- |
+| `BUCKET.t3.tigrisfiles.io`  | `https://my-assets.t3.tigrisfiles.io/logo.png`  |
+| `BUCKET.t3.tigrisbucket.io` | `https://my-assets.t3.tigrisbucket.io/logo.png` |
+| `BUCKET.t3.tigrisblob.io`   | `https://my-assets.t3.tigrisblob.io/logo.png`   |
 
-No additional configuration required.
+Pick whichever you prefer. All work out of the box with no additional
+configuration. Each uses the bucket name as a subdomain.
+
+## Why three domains?
+
+If one domain has issues, you can switch to another immediately. We can rotate
+domains without disrupting every user at once.
 
 This change only affects how public content is served to anonymous visitors. All
 authenticated operations — uploading, listing, deleting, and managing objects

--- a/blog/2026-04-02-public-bucket-domains/index.mdx
+++ b/blog/2026-04-02-public-bucket-domains/index.mdx
@@ -40,22 +40,13 @@ New Tigris accounts serve public content — both
 [public objects in private buckets](https://www.tigrisdata.com/docs/objects/public-objects/)
 — from `t3.tigrisfiles.io` instead of `t3.storage.dev`.
 
-Public content is available on three dedicated domains, all serving the same
-content:
+Public content URLs use the bucket name as a subdomain:
 
-| Domain                      | Example URL                                     |
-| --------------------------- | ----------------------------------------------- |
-| `BUCKET.t3.tigrisfiles.io`  | `https://my-assets.t3.tigrisfiles.io/logo.png`  |
-| `BUCKET.t3.tigrisbucket.io` | `https://my-assets.t3.tigrisbucket.io/logo.png` |
-| `BUCKET.t3.tigrisblob.io`   | `https://my-assets.t3.tigrisblob.io/logo.png`   |
+```
+https://my-assets.t3.tigrisfiles.io/logo.png
+```
 
-Pick whichever you prefer. All work out of the box with no additional
-configuration. Each uses the bucket name as a subdomain.
-
-## Why three domains?
-
-If one domain has issues, you can switch to another immediately. We can rotate
-domains without disrupting every user at once.
+No additional configuration required.
 
 This change only affects how public content is served to anonymous visitors. All
 authenticated operations — uploading, listing, deleting, and managing objects
@@ -95,6 +86,18 @@ should point to `BUCKET.t3.tigrisbucket.io` as described in the
 
 For production public content, we recommend a custom domain. It keeps your URLs
 stable regardless of platform domain changes.
+
+## Alternate domains
+
+Two additional domains serve the same public content as `t3.tigrisfiles.io`:
+
+| Domain                      | Example URL                                     |
+| --------------------------- | ----------------------------------------------- |
+| `BUCKET.t3.tigrisbucket.io` | `https://my-assets.t3.tigrisbucket.io/logo.png` |
+| `BUCKET.t3.tigrisblob.io`   | `https://my-assets.t3.tigrisblob.io/logo.png`   |
+
+If `t3.tigrisfiles.io` has issues, you can switch to either of these
+immediately.
 
 ## Getting started
 

--- a/blog/2026-04-02-public-bucket-domains/index.mdx
+++ b/blog/2026-04-02-public-bucket-domains/index.mdx
@@ -1,8 +1,8 @@
 ---
 slug: public-bucket-domains
-title: "Introducing tigrisfiles.io for public content"
+title: "Introducing t3.tigrisfiles.io for public content"
 description: |
-  New Tigris accounts serve public content from a dedicated domain — tigrisfiles.io — separating public content delivery from API infrastructure.
+  New Tigris accounts serve public content from a dedicated domain — t3.tigrisfiles.io — separating public content delivery from API infrastructure.
 image: ./hero-image.webp
 keywords:
   - public buckets
@@ -24,11 +24,11 @@ import heroImage from "./hero-image.webp";
 <img
   src={heroImage}
   className="hero-image"
-  alt="Introducing tigrisfiles.io for Tigris public content"
+  alt="Introducing t3.tigrisfiles.io for Tigris public content"
 />
 
 New Tigris accounts now serve public content from a dedicated domain:
-`tigrisfiles.io`. This separates public content delivery from API
+`t3.tigrisfiles.io`. This separates public content delivery from API
 infrastructure.
 
 {/* truncate */}
@@ -38,7 +38,7 @@ infrastructure.
 New Tigris accounts serve public content — both
 [public buckets](https://www.tigrisdata.com/docs/buckets/public-bucket/) and
 [public objects in private buckets](https://www.tigrisdata.com/docs/objects/public-objects/)
-— from `tigrisfiles.io` instead of `t3.storage.dev`.
+— from `t3.tigrisfiles.io` instead of `t3.storage.dev`.
 
 Public content URLs use the bucket name as a subdomain:
 
@@ -54,7 +54,7 @@ through the CLI, SDKs, or S3 API — continue to use `t3.storage.dev`. When you
 use an SDK, every request is authenticated, whether the bucket is public or
 private. The only thing that changes is the URL you hand out for public access.
 
-Presigned URLs generated through the Tigris Console now use `tigrisfiles.io`
+Presigned URLs generated through the Tigris Console now use `t3.tigrisfiles.io`
 automatically. Presigned URLs you generate in your own code continue to work on
 whichever endpoint you already use.
 
@@ -67,7 +67,7 @@ Organizations, namespaces, and buckets belonging to known partners are also
 excluded regardless of account age.
 
 `fly.storage.tigris.dev`, used by many Fly.io users, follows the same rules. New
-accounts should use `tigrisfiles.io` for public content instead.
+accounts should use `t3.tigrisfiles.io` for public content instead.
 
 To switch existing content to the new domain, swap the hostname:
 


### PR DESCRIPTION
## Summary
- Remove the "Does this affect the API?" section that positioned tigrisfiles.io as an API/CLI/SDK endpoint
- Clarify that tigrisfiles.io is only for public anonymous access
- Private access (CLI, SDKs, S3 API) continues using t3.storage.dev

## Test plan
- [ ] Verify post renders correctly with `npm run start`
- [ ] Confirm no remaining references to using tigrisfiles.io for API/CLI/SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that clarify domain usage; no product code or runtime behavior is modified.
> 
> **Overview**
> Updates the `public-bucket-domains` blog post and social copy to announce **`t3.tigrisfiles.io`** (instead of `tigrisfiles.io`) as the dedicated domain for *anonymous public* bucket/object access.
> 
> Removes language implying this domain is an API/CLI/SDK endpoint, explicitly stating authenticated operations remain on `t3.storage.dev`, and adds an *Alternate domains* section listing `BUCKET.t3.tigrisbucket.io` and `BUCKET.t3.tigrisblob.io` as equivalent fallbacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24c964640fa04708387640aeed69b8daba53f6a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->