### PR TITLE
fix: optimize build process for docsite

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .docusaurus
-          key: docusaurus-${{ hashFiles('package-lock.json') }}-${{ github.sha }}
+          key:
+            docusaurus-${{ hashFiles('package-lock.json') }}-${{ github.sha }}
           restore-keys: |
             docusaurus-${{ hashFiles('package-lock.json') }}-
             docusaurus-

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,25 +6,49 @@ env:
   NEXT_PUBLIC_POSTHOG_APIKEY: dummy_for_testing
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Pull submodules
-        run: git submodule update --init --recursive
-
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Check category tags
         run: ./scripts/check-category-tags.sh
 
-      - name: Check types + linting + build
-        run: |
-          npm install
-          npx prettier --check .
-          npx eslint .
-          npm run build
+      - name: Prettier
+        run: npx prettier --check .
+
+      - name: ESLint
+        run: npx eslint .
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Restore Docusaurus cache
+        uses: actions/cache@v4
+        with:
+          path: .docusaurus
+          key: docusaurus-${{ hashFiles('package-lock.json') }}-${{ github.sha }}
+          restore-keys: |
+            docusaurus-${{ hashFiles('package-lock.json') }}-
+            docusaurus-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,7 +11,6 @@ const tigrisConfig = require("./tigris.config");
 
 const lightCodeTheme = require("prism-react-renderer").themes.github;
 const darkCodeTheme = require("prism-react-renderer").themes.dracula;
-const simplePlantUML = require("@akebifiky/remark-simple-plantuml");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -58,7 +57,7 @@ const config = {
             type: "all",
             copyright: `Copyright © ${new Date().getFullYear()} Tigris Data, Inc.`,
           },
-          remarkPlugins: [simplePlantUML],
+          remarkPlugins: [],
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "blog",
       "version": "0.0.0",
       "dependencies": {
-        "@akebifiky/remark-simple-plantuml": "^1.0.2",
         "@docusaurus/core": "^3.1.1",
         "@docusaurus/preset-classic": "^3.1.1",
         "@docusaurus/theme-mermaid": "^3.1.1",
@@ -34,22 +33,11 @@
         "eslint": "^8.12.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-react": "^7.29.4",
-        "playwright": "^1.57.0",
         "prettier": "2.8.8",
         "typescript": "~5.2.2"
       },
       "engines": {
         "node": ">=18.0"
-      }
-    },
-    "node_modules/@akebifiky/remark-simple-plantuml": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@akebifiky/remark-simple-plantuml/-/remark-simple-plantuml-1.0.2.tgz",
-      "integrity": "sha512-y5rWgQvU+DMpLKx1KlXCsgUeqVooqQm1S3hePLF9iecZy6YhKRybznFdvAvoAoiV2GoGhObQDHnneAl93llIcg==",
-      "license": "MIT",
-      "dependencies": {
-        "plantuml-encoder": "^1.4.0",
-        "unist-util-visit": "^2.0.2"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -16772,59 +16760,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/plantuml-encoder": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/plantuml-encoder/-/plantuml-encoder-1.4.0.tgz",
-      "integrity": "sha512-sxMwpDw/ySY1WB2CE3+IdMuEcWibJ72DDOsXLkSmEaSzwEUaYBT6DWgOfBiHGCux4q433X6+OEFWjlVqp7gL6g==",
-      "license": "MIT"
-    },
-    "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.57.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/points-on-curve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
@@ -21320,21 +21255,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unist-util-visit": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0",
-        "unist-util-visit-parents": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/unist-util-visit-parents": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
@@ -21343,36 +21263,6 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit/node_modules/@types/unist": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-      "license": "MIT"
-    },
-    "node_modules/unist-util-visit/node_modules/unist-util-is": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit/node_modules/unist-util-visit-parents": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "seo:apply:all": "node seo-reviewer.mjs --all --apply"
   },
   "dependencies": {
-    "@akebifiky/remark-simple-plantuml": "^1.0.2",
     "@docusaurus/core": "^3.1.1",
     "@docusaurus/preset-classic": "^3.1.1",
     "@docusaurus/theme-mermaid": "^3.1.1",
@@ -55,7 +54,6 @@
     "eslint": "^8.12.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-react": "^7.29.4",
-    "playwright": "^1.57.0",
     "prettier": "2.8.8",
     "typescript": "~5.2.2"
   },


### PR DESCRIPTION
Here is what I did to the files

`.github/workflows/test.yaml `— rewritten:

- Upgraded actions/checkout from v2 to v4 and actions/setup-node from v3 to v4
- Added cache: "npm" to setup-node so npm packages are cached between runs
- Switched npm install to npm ci for faster, deterministic installs
- Added actions/cache@v4 for the .docusaurus build cache directory
- Split into two parallel jobs (lint and build) so formatting/linting runs concurrently with the Docusaurus build
- Removed the no-op git submodule update step

`docusaurus.config.js` — removed the unused @akebifiky/remark-simple-plantuml require and plugin reference

`package.json` — uninstalled playwright (unused devDependency) and @akebifiky/remark-simple-plantuml (no PlantUML content in any blog post)

Build verified passing locally after all changes.