### PR TITLE
fix: address remaining review comments on antithesis post

### DIFF
--- a/blog/2026-04-16-cache-coherence-antithesis/before-after.svg
+++ b/blog/2026-04-16-cache-coherence-antithesis/before-after.svg
@@ -44,7 +44,7 @@
   <text x="1080" y="330" fill="#c8d6de" font-size="15" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" text-anchor="middle" opacity="1"><tspan x="1080" dy="0">3. delete from FDB</tspan></text>
 
   <g opacity="1"><rect x="840" y="365" width="480" height="50" rx="8" ry="8" fill="#142229" stroke="#2a4050" stroke-width="2"/></g>
-  <text x="1080" y="395" fill="#c8d6de" font-size="15" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" text-anchor="middle" opacity="1"><tspan x="1080" dy="0">4. (deferred) evict again + write tombstone</tspan></text>
+  <text x="1080" y="395" fill="#c8d6de" font-size="15" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" text-anchor="middle" opacity="1"><tspan x="1080" dy="0">4. (deferred) write tombstone</tspan></text>
 
   <g opacity="1"><rect x="840" y="430" width="480" height="50" rx="8" ry="8" fill="#142229" stroke="#2a4050" stroke-width="2"/></g>
   <text x="1080" y="460" fill="#c8d6de" font-size="15" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" text-anchor="middle" opacity="1"><tspan x="1080" dy="0">5. release lock</tspan></text>

--- a/blog/2026-04-16-cache-coherence-antithesis/delete-race.svg
+++ b/blog/2026-04-16-cache-coherence-antithesis/delete-race.svg
@@ -28,7 +28,7 @@
 
   <!-- Stale window zone -->
   <g opacity="0.15"><rect x="100" y="320" width="1200" height="140" rx="8" ry="8" fill="#CF5B5B" stroke="#CF5B5B" stroke-width="1.5" stroke-dasharray="6 4"/></g>
-  <text x="112" y="342" fill="#CF5B5B" font-size="14" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="112" dy="0">STALE WINDOW — eviction failed, cache still serves deleted object until TTL expires</tspan></text>
+  <text x="112" y="342" fill="#CF5B5B" font-size="14" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="112" dy="0">STALE WINDOW — eviction failed, cache still serves deleted objects until TTL expires or async invalidation happens</tspan></text>
 
   <!-- Step 1: acquire lock -->
   <g opacity="1"><path d="M150,200 L430,200" fill="none" stroke="#c8d6de" stroke-width="2" stroke-linecap="round"/><polyline points="423.5,204.7 430,200 423.5,195.3" fill="none" stroke="#c8d6de" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></g>

--- a/blog/2026-04-16-cache-coherence-antithesis/index.mdx
+++ b/blog/2026-04-16-cache-coherence-antithesis/index.mdx
@@ -186,11 +186,10 @@ on its TTL.
 
 The eviction can fail for plenty of reasons. Tigris has two mechanisms that
 clear stale cache entries: an async invalidation task that fans out to every
-gateway after FDB commits, and a TTL on each cache entry that eventually ages it
-out. If the process crashes before the async task runs, or the task itself
-fails, or the cache call times out, the only mechanism left is TTL. FDB has
-moved on and the cache sits frozen in the past. The entry survives and every
-read during that window returns the deleted object.
+region after FDB commits, and a TTL on each cache entry that eventually ages it
+out. If the task itself fails, or the cache call times out, the only mechanism
+left is TTL. FDB has moved on and the cache sits frozen in the past. The entry
+survives and every read during that window returns the deleted object.
 
 This is a
 [linearizability](https://cs.brown.edu/~mph/HerlihyW90/p463-herlihy.pdf)
@@ -263,20 +262,20 @@ delete(key):
   1. acquire key lock
   2. evict cache entry          ← moved before FDB delete
   3. delete from FDB
-  4. (deferred) evict again
-     + write tombstone          ← defense-in-depth
+  4. (deferred) write tombstone ← defense-in-depth
   5. release key lock
 ```
 
 The eager eviction clears the cache before FDB commits, so any subsequent read
 finds the cache empty and falls through to FDB. We swallow the eviction error on
 purpose: if the cache is temporarily unreachable, the FDB delete still proceeds.
-The deferred eviction and tombstone still run afterward as defense in depth.
+The deferred addition of the tombstone still establishes the read barrier
+afterward as additional defense in depth.
 
 <MermaidFrame style={{ maxWidth: "46rem", margin: "1.5rem auto" }}>
   <BeforeAfter
     role="img"
-    aria-label="Side-by-side comparison of the delete path. Before: lock, FDB delete, deferred evict that can fail silently, deferred tombstone, unlock. After: lock, evict cache before FDB delete, FDB delete, deferred evict plus tombstone, unlock. Cache cleared before FDB commits."
+    aria-label="Side-by-side comparison of the delete path. Before: lock, FDB delete, deferred evict that can fail silently, deferred tombstone, unlock. After: lock, evict cache before FDB delete, FDB delete, deferred tombstone, unlock. Cache cleared before FDB commits."
     style={{ width: "100%", height: "auto" }}
   />
 </MermaidFrame>
@@ -355,15 +354,23 @@ layer catches a class of failure the one above cannot:
   entry is written, the code compares its timestamp to the tombstone, and if the
   tombstone is newer the write is skipped. Even if a fallback read delivers a
   stale copy, the tombstone keeps it from poisoning the cache.
-- **Metadata layer: tombstone returns.** The first two layers live in the cache
-  and don't help when the gateway reconciles responses across regions. A 404
-  response from the metadata layer carries no timestamp, so a delete can't be
-  compared against a stale entry in cache, and the stale one is served. The fix
-  extended the metadata response to return the tombstone record itself when a
-  key has been deleted, with the time of delete. The gateway now compares the
-  cache entry's timestamp against the tombstone's, returns the correct result,
-  and evicts the stale cache entry on the way out. This is the safety net for
-  cases where the cache is absent or the tombstone barrier never landed.
+- **Metadata layer: tombstone returns.** The tombstone barrier in cache is the
+  first line of defense against serving deleted objects, but as part of this
+  testing we also wanted to harden the path that does not rely on cache at all.
+  When the gateway reconciles responses across regions and the local cluster no
+  longer has the key, we need to ensure it does not select a stale copy from a
+  remote cluster. In normal operation, this path is typically masked by the
+  tombstone barrier in cache, which causes the request to resolve to a 404
+  before reconciliation ever becomes relevant. But this testing is intentionally
+  focused on the cases where that protection is not present — for example, if
+  tombstone barriers are not cached, or if the cache is bypassed entirely. To
+  make that path robust on its own, the fix extends the metadata response to
+  return the tombstone record itself, including the delete timestamp, when a key
+  has been removed. That gives the gateway enough information to compare the
+  delete against remote responses, make the correct decision during
+  reconciliation, and return the right result. Cache remains the first barrier,
+  but this ensures correctness even when tombstone barrier caching is disabled,
+  skipped, or otherwise never comes into play.
 
 <MermaidFrame style={{ maxWidth: "42rem", margin: "1.5rem auto" }}>
   <ThreeLayerStack

--- a/blog/2026-04-16-cache-coherence-antithesis/three-layer-stack.svg
+++ b/blog/2026-04-16-cache-coherence-antithesis/three-layer-stack.svg
@@ -21,8 +21,8 @@
   <g opacity="1"><rect x="280" y="480" width="900" height="130" rx="8" ry="8" fill="#142229" stroke="#CF8E5B" stroke-width="2.5"/></g>
   <text x="300" y="514" fill="#CF8E5B" font-size="14" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="300" dy="0">L3</tspan></text>
   <text x="340" y="520" fill="#c8d6de" font-size="20" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="340" dy="0">Metadata Layer — Tombstone Returns</tspan></text>
-  <text x="300" y="553" fill="#8fa3b0" font-size="13" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="300" dy="0">404 responses now carry the tombstone record with deletion timestamp.</tspan></text>
-  <text x="300" y="583" fill="#8fa3b0" font-size="13" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="300" dy="0">Gateway compares cache entry against tombstone, evicts stale data on the way out.</tspan></text>
+  <text x="300" y="553" fill="#8fa3b0" font-size="13" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="300" dy="0">Metadata response returns tombstone record with delete timestamp.</tspan></text>
+  <text x="300" y="583" fill="#8fa3b0" font-size="13" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="300" dy="0">Gateway compares delete against remote responses during reconciliation.</tspan></text>
 
   <!-- Failure modes arrow -->
   <g opacity="1"><path d="M180,580 L180,180" fill="none" stroke="#CF5B5B" stroke-width="2.5" stroke-linecap="round"/><polyline points="184.7,186.5 180,180 175.3,186.5" fill="none" stroke="#CF5B5B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></g>
@@ -44,7 +44,7 @@
 
   <g opacity="0.5"><rect x="1230" y="480" width="300" height="130" rx="8" ry="8" fill="#142229" stroke="#1e3340" stroke-width="1" stroke-dasharray="6 4"/></g>
   <text x="1250" y="511" fill="#8fa3b0" font-size="13" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="1250" dy="0">Catches</tspan></text>
-  <text x="1250" y="543" fill="#c8d6de" font-size="13" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="1250" dy="0">Stale cache entries when</tspan></text>
-  <text x="1250" y="565" fill="#c8d6de" font-size="13" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="1250" dy="0">tombstone barrier is absent</tspan></text>
-  <text x="1250" y="587" fill="#c8d6de" font-size="13" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="1250" dy="0">or never landed.</tspan></text>
+  <text x="1250" y="543" fill="#c8d6de" font-size="13" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="1250" dy="0">Stale remote copies when</tspan></text>
+  <text x="1250" y="565" fill="#c8d6de" font-size="13" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="1250" dy="0">cache is bypassed or</tspan></text>
+  <text x="1250" y="587" fill="#c8d6de" font-size="13" font-family="Virgil, 'Comic Sans MS', cursive, sans-serif" opacity="1"><tspan x="1250" dy="0">tombstone barrier not cached.</tspan></text>
 </svg>


### PR DESCRIPTION
## Summary
- Applies himank's review feedback from PR #379 that was not addressed before merge
- Rewrites the **Metadata layer: tombstone returns** (L3) section to properly explain the reconciliation path and when it matters
- Fixes "every gateway" → "every region", removes "evict again" from deferred step, simplifies process crash sentence
- Updates delete-race.svg, before-after.svg, and three-layer-stack.svg to match text changes

## Test plan
- [x] `npm run build` passes
- [ ] Visual check of SVG diagrams renders correctly
- [ ] Review metadata layer section reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)