### PR TITLE
fix: correct consistency model in antithesis post

### DIFF
--- a/blog/2026-04-16-cache-coherence-antithesis/index.mdx
+++ b/blog/2026-04-16-cache-coherence-antithesis/index.mdx
@@ -436,7 +436,7 @@ with AI coding assistants, if you want to try the approach on your own system.
 
 <InlineCta
   title="Strong consistency, tested under fault"
-  subtitle="Tigris is S3-compatible object storage with strong consistency within a region, eventual consistency across regions, and sub-second replication. Tested in Antithesis every night."
+  subtitle="Tigris is S3-compatible object storage with strong consistency for all same-region requests and cross-region on single-region and multi-region buckets. Tested in Antithesis every night."
   button="Read the docs"
   link="https://www.tigrisdata.com/docs/"
 />

--- a/blog/2026-04-16-cache-coherence-antithesis/index.mdx
+++ b/blog/2026-04-16-cache-coherence-antithesis/index.mdx
@@ -67,12 +67,15 @@ import ThreeLayerStack from "./three-layer-stack.svg";
 
 {/* truncate */}
 
-Tigris is an S3-compatible object storage service with strong consistency within
-a region and eventual consistency across regions, with sub-second replication
-lag. A PUT returns; the next GET from the same region returns the object. A
-DELETE returns; the next GET returns 404. Conditional operations evaluate
-against the latest state. Those are the guarantees we sell, and they have to
-hold under fault.
+Tigris is an S3-compatible object storage service. All same-region requests get
+[strong consistency](https://www.tigrisdata.com/docs/concepts/consistency/)
+regardless of bucket type. Cross-region requests are also strongly consistent
+for single-region and multi-region buckets; global and dual-region buckets trade
+that for availability, with eventual consistency and sub-second replication lag.
+A PUT returns; the next GET from the same region returns the object. A DELETE
+returns; the next GET returns 404. Conditional operations evaluate against the
+latest state. Those are the guarantees we sell, and they have to hold under
+fault.
 
 To hit the latency budget, every read goes through the edge cache in front of
 FoundationDB (FDB) metadata and block storage. A cache hit returns without ever

--- a/blog/2026-04-16-cache-coherence-antithesis/two-layer-read.svg
+++ b/blog/2026-04-16-cache-coherence-antithesis/two-layer-read.svg
@@ -50,8 +50,7 @@
 
   <!-- Blocks -->
   <rect x="560" y="200" width="170" height="50" class="node" />
-  <text x="645" y="222" text-anchor="middle" class="label">Block storage</text>
-  <text x="645" y="240" text-anchor="middle" class="small">S3</text>
+  <text x="645" y="232" text-anchor="middle" class="label">Block storage</text>
 
   <!-- Forward request arrows: Client → Gateway → Edge cache -->
   <line x1="140" y1="180" x2="186" y2="180" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrGrey)" />


### PR DESCRIPTION
## Summary
- Updates the opening paragraph of the antithesis post to accurately describe Tigris's consistency model per [the docs](https://www.tigrisdata.com/docs/concepts/consistency/)
- The old text said "strong consistency within a region and eventual consistency across regions" — this is incomplete
- The actual model: all same-region requests are strongly consistent regardless of bucket type; cross-region is also strong for single-region and multi-region buckets; only global and dual-region buckets use eventual consistency cross-region
- Adds a link to the consistency docs page

## Test plan
- [x] `npm run build` passes
- [ ] Review updated paragraph for accuracy against docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)