### PR TITLE
fix: correct Antithesis companion post URL

### DIFF
--- a/blog/2026-04-16-cache-coherence-antithesis/index.mdx
+++ b/blog/2026-04-16-cache-coherence-antithesis/index.mdx
@@ -428,7 +428,7 @@ Three targets:
 Antithesis's companion post goes deeper on the methodology side — how the
 simulator explores, how determinism enables replay, what a property-based test
 under fault injection actually looks like.
-[Read it for the testing-methodology view.](https://antithesis.com/blog/2026/tigrisdata/)
+[Read it for the testing-methodology view.](https://antithesis.com/blog/2026/tigris_report/)
 
 Antithesis also recently open-sourced
 [skills for writing Antithesis tests](https://github.com/antithesishq/antithesis-skills)


### PR DESCRIPTION
## Summary
- Fixes the Antithesis companion post link in the conclusion of the cache coherence post
- URL was `/blog/2026/tigrisdata/` → `/blog/2026/tigris_report/`

## Test plan
- [ ] Verify the link resolves correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)