### PR TITLE
Add rb2b and PostHog bridge to blog (via existing plugin)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,6 +13,18 @@ const lightCodeTheme = require("prism-react-renderer").themes.github;
 const darkCodeTheme = require("prism-react-renderer").themes.dracula;
 const simplePlantUML = require("@akebifiky/remark-simple-plantuml");
 
+const rb2bHeadTag =
+  process.env.VERCEL_ENV === "production"
+    ? [
+        {
+          tagName: "script",
+          attributes: {},
+          innerHTML:
+            '(function(){var m=document.cookie.match(/(?:^|; )tigris_geo=([^;]*)/);var c=m?decodeURIComponent(m[1]):"";if(c!=="US"&&c!=="CA")return;if(window.reb2b)return;window.reb2b={loaded:true};var s=document.createElement("script");s.async=true;s.src="/_tigris/insights/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz";var f=document.getElementsByTagName("script")[0];f.parentNode.insertBefore(s,f);})();',
+        },
+      ]
+    : [];
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Tigris Object Storage",
@@ -31,8 +43,11 @@ const config = {
   },
   themes: ["@docusaurus/theme-mermaid"],
 
+  headTags: [...rb2bHeadTag],
+
   clientModules: [
     require.resolve("./src/util/ensureGtag.js"),
+    require.resolve("./src/util/posthog.js"),
     require.resolve("./src/util/augmentConsoleLinks.js"),
     require.resolve("./src/util/hideNavbarInBlogPost.js"),
   ],

--- a/src/util/augmentConsoleLinks.js
+++ b/src/util/augmentConsoleLinks.js
@@ -5,35 +5,37 @@ export function onRouteDidUpdate({ location, previousLocation }) {
     // Don't execute if we are still on the same page; the lifecycle may be fired
     // because the hash changes (e.g. when navigating between headings)
     if (location.pathname !== previousLocation?.pathname) {
-      // PostHog should be available with the exception of in the development
-      // environment
+      // PostHog's loader creates a truthy stub before the library finishes
+      // loading; its get_distinct_id / get_session_id return undefined.
+      // Also check __loaded so we don't stamp ?pid=undefined&sid=undefined
+      // onto links. onRouteDidUpdate retries on the next navigation.
       const posthog = window.posthog;
-      if (!posthog) {
-        console.warn("Cannot set 'pid' for console links");
+      if (!posthog || !posthog.__loaded) {
         return;
       }
+
+      const pid = posthog.get_distinct_id();
+      const sid = posthog.get_session_id();
+      if (!pid || !sid) return;
 
       // Get all anchors that contain the console URL
       const allSignupLinks = document.querySelectorAll(
         `a[href*="${tigrisConfig.consoleUrl}`
       );
 
-      const existingPid = location.searchParams?.get("pid");
-      const existingSid = location.searchParams?.get("sid");
-      const pid = existingPid || posthog.get_distinct_id();
-      const sid = existingSid || posthog.get_session_id();
+      // Always overwrite pid/sid so links re-stamped on an earlier route
+      // change pick up the current PostHog identity (e.g., after the rb2b
+      // bridge calls posthog.identify and the distinct_id switches from
+      // the anonymous UUID to rb2b_<uid>).
       allSignupLinks.forEach((el) => {
         const href = new URL(el.getAttribute("href"));
-
-        if (href.searchParams.has("pid") === false) {
+        if (href.searchParams.get("pid") !== pid) {
           href.searchParams.set("pid", pid);
-          el.setAttribute("href", href.toString());
         }
-
-        if (href.searchParams.has("sid") === false) {
+        if (href.searchParams.get("sid") !== sid) {
           href.searchParams.set("sid", sid);
-          el.setAttribute("href", href.toString());
         }
+        el.setAttribute("href", href.toString());
       });
     }
   } catch (e) {

--- a/src/util/posthog.js
+++ b/src/util/posthog.js
@@ -1,0 +1,64 @@
+function getCookie(name) {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(
+    new RegExp("(?:^|; )" + name + "=([^;]*)")
+  );
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+let pollInProgress = false;
+let lastPageviewUrl = null;
+
+function startRb2bPostHogBridge() {
+  if (pollInProgress) return;
+
+  const country = getCookie("tigris_geo");
+  if (country !== "US" && country !== "CA") return;
+
+  const posthog = window.posthog;
+  if (
+    posthog &&
+    posthog.__loaded &&
+    typeof posthog.get_distinct_id === "function" &&
+    String(posthog.get_distinct_id() ?? "").startsWith("rb2b_")
+  ) {
+    return;
+  }
+
+  pollInProgress = true;
+  let attempts = 0;
+  const iv = window.setInterval(() => {
+    attempts++;
+    const uid = getCookie("_reb2buid");
+    const ph = window.posthog;
+    if (uid && ph && typeof ph.identify === "function") {
+      ph.identify(`rb2b_${uid}`);
+      ph.register({ rb2b_visitor_id: uid });
+      pollInProgress = false;
+      window.clearInterval(iv);
+    } else if (attempts >= 60) {
+      pollInProgress = false;
+      window.clearInterval(iv);
+    }
+  }, 500);
+}
+
+export function onRouteDidUpdate({ location, previousLocation }) {
+  if (typeof window === "undefined") return;
+
+  if (location.pathname !== previousLocation?.pathname) {
+    // posthog-docusaurus auto-captures $pageview on each route change but
+    // does not emit a corresponding $pageleave for the page being left —
+    // PostHog's built-in pageleave only fires on real tab close /
+    // visibilitychange. Without an explicit $pageleave, dwell-time math
+    // for per-page sessions is wrong. Emit it manually using the URL we
+    // recorded for the previous $pageview so the two events align.
+    const posthog = window.posthog;
+    if (posthog && typeof posthog.capture === "function" && lastPageviewUrl) {
+      posthog.capture("$pageleave", { $current_url: lastPageviewUrl });
+    }
+    lastPageviewUrl = window.location.href;
+  }
+
+  startRb2bPostHogBridge();
+}


### PR DESCRIPTION
## Summary
Blog pages had no rb2b coverage and `augmentConsoleLinks.js` silently warned `"Cannot set 'pid' for console links"` on every route change because PostHog wasn't actually initialized.

This PR uses the **existing dormant** `posthog-docusaurus` plugin (already in this repo's config, gated on `NEXT_PUBLIC_POSTHOG_APIKEY` + `NEXT_PUBLIC_POSTHOG_HOST` env vars) to handle PostHog init + `$pageview` capture, and only adds the small pieces the plugin can't provide:

- **`docusaurus.config.js` `headTags`** (new field): production-only rb2b initializer that reads the `tigris_geo` cookie set by the marketing site's edge middleware, gates on US/CA, and loads the CDN bundle through the marketing site's `/_tigris/insights/...` rewrite.
- **`src/util/posthog.js`** (new client module):
  - Polls `_reb2buid` for up to 30s after each route change and calls `posthog.identify('rb2b_<uid>')` + `posthog.register({ rb2b_visitor_id })`. Mirror of the marketing site's `Rb2bPostHogBridge`.
  - Manually emits `$pageleave` on Docusaurus SPA navigations using the URL recorded for the previous `$pageview`. `posthog-docusaurus` doesn't do this — it only relies on PostHog's built-in pageleave which only fires on real tab close / visibilitychange.
  - Geo-gates and retries on cookie-miss + timeout.
- **`src/util/augmentConsoleLinks.js`**: check `posthog.__loaded` (not just truthy — the snippet stub is truthy but its getters return undefined, producing literal `?pid=undefined`). Always overwrite `pid` / `sid` so links re-stamped before `identify()` pick up the `rb2b_<uid>` distinct_id on the next navigation.

The dormant `posthog-docusaurus` plugin config and its package.json dependency are left untouched.

## Required env var change in Vercel
Production env vars on the blog Vercel project need to be set:

- `NEXT_PUBLIC_POSTHOG_APIKEY` (the same PostHog project key used by the marketing site — pull it from the marketing site's Vercel env or from PostHog → Project Settings)
- `NEXT_PUBLIC_POSTHOG_HOST=https://ph.tigrisdata.com`

After those are set and this PR deploys, the plugin activates and PostHog is initialized — same project, same person record shared across marketing / docs / blog on the `.tigrisdata.com` origin.

## Test plan
- [ ] Set the two env vars in Vercel production for the blog project.
- [ ] After merge + deploy, visit a blog page from a US/CA IP in Incognito.
- [ ] Network: PostHog loader from `ph.tigrisdata.com` and rb2b script from `/_tigris/insights/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz`, both 200.
- [ ] Console: `window.posthog.__loaded === true`, `get_distinct_id()` returns PostHog UUID initially, then `rb2b_<uid>` once `_reb2buid` lands.
- [ ] Console signup links: `?pid=...&sid=...` populated, refreshed to the rb2b_* distinct_id on next navigation after identify.
- [ ] PostHog activity: one `$pageview` per route change, one matching `$pageleave` for the page being left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)