### PR TITLE
Fire rb2b.collect() on Docusaurus SPA route changes

### DIFF
--- a/src/util/posthog.js
+++ b/src/util/posthog.js
@@ -58,6 +58,16 @@ export function onRouteDidUpdate({ location, previousLocation }) {
       posthog.capture("$pageleave", { $current_url: lastPageviewUrl });
     }
     lastPageviewUrl = window.location.href;
+
+    // rb2b's CDN bundle auto-captures the initial pageview but not
+    // subsequent SPA navigations. Without this call, every visitor looks
+    // like a single-pageview visit in rb2b's pipeline, which throttles
+    // their identification volume. Skip the initial render (handled by
+    // rb2b's own bootstrap).
+    const reb2b = window.reb2b;
+    if (previousLocation && reb2b && typeof reb2b.collect === "function") {
+      reb2b.collect();
+    }
   }
 
   startRb2bPostHogBridge();


### PR DESCRIPTION
## Summary
rb2b's CDN bundle auto-captures the initial pageview when it loads, but Docusaurus uses SPA navigation for in-app links — the page doesn't reload, so rb2b sees only one pageview per visitor session no matter how many blog posts they read. Their support confirmed this is what's been throttling identification volume: each visit looks like a single-pageview session in their pipeline.

This PR adds a \`window.reb2b.collect()\` call to the existing \`onRouteDidUpdate\` hook in \`src/util/posthog.js\`, next to the manual \`\$pageleave\` emit since both are "do something on each SPA route change."

Same pattern is also being added to:
- The docs: tigrisdata/tigris-os-docs#471
- The marketing site: tigrisdata/website#292

## Guards
- Only fires when \`previousLocation\` is set (skips the initial render — rb2b's bootstrap already captured that pageview).
- No-op when \`window.reb2b.collect\` isn't a function (visitor outside US/CA so the script never loaded, privacy blocker stripped it, etc.).

## Test plan
- [ ] After deploy, visit a blog post on \`https://www.tigrisdata.com/blog/\` from a US/CA IP in Incognito.
- [ ] Wait for the \`_reb2buid\` cookie to land and \`window.reb2b.collect\` to be a function.
- [ ] Click an in-page link to navigate to another blog post.
- [ ] Network tab should show a new request to \`app.rb2b.com\` shortly after the URL change.
- [ ] Repeat with several more navigations — each should produce a fresh \`app.rb2b.com\` request.
- [ ] After ~24h of real traffic, rb2b's dashboard should show meaningfully higher identification volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a guarded analytics call on Docusaurus route transitions and no-ops when `window.reb2b.collect` is unavailable, with no impact on core app logic.
> 
> **Overview**
> Ensures rb2b records pageviews for Docusaurus SPA navigations by calling `window.reb2b.collect()` inside `onRouteDidUpdate` when the pathname changes.
> 
> The call is **guarded** to skip the initial render (`previousLocation` must be set) and to no-op unless `window.reb2b.collect` is a function, and it’s co-located with the existing manual PostHog `$pageleave` emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f86db20f27c0906a50a077c7009382c0785cf827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->