### PR TITLE
Load rb2b script directly from CloudFront

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -20,7 +20,7 @@ const rb2bHeadTag =
           tagName: "script",
           attributes: {},
           innerHTML:
-            '(function(){var m=document.cookie.match(/(?:^|; )tigris_geo=([^;]*)/);var c=m?decodeURIComponent(m[1]):"";if(c!=="US"&&c!=="CA")return;if(window.reb2b)return;window.reb2b={loaded:true};var s=document.createElement("script");s.async=true;s.src="/_tigris/insights/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz";var f=document.getElementsByTagName("script")[0];f.parentNode.insertBefore(s,f);})();',
+            '(function(){var m=document.cookie.match(/(?:^|; )tigris_geo=([^;]*)/);var c=m?decodeURIComponent(m[1]):"";if(c!=="US"&&c!=="CA")return;if(window.reb2b)return;window.reb2b={loaded:true};var s=document.createElement("script");s.async=true;s.src="https://ddwl4m2hdecbv.cloudfront.net/b/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz";var f=document.getElementsByTagName("script")[0];f.parentNode.insertBefore(s,f);})();',
         },
       ]
     : [];


### PR DESCRIPTION
## Summary
Same revert as the marketing site (tigrisdata/website#294) and docs (tigrisdata/tigris-os-docs#472).

The \`/_tigris/insights/\` proxy URL stopped working after rb2b shipped a bundle update that does hostname / origin validation and refuses to operate when loaded from anywhere other than \`cloudfront.net\`. Direct loads of the byte-identical script still work. Until rb2b clarifies how to satisfy the validation for proxied installs, point \`s.src\` at their CloudFront directly so identifications start flowing again.

## Trade-off
Privacy blockers (uBlock, Brave Shields, AdGuard, etc.) match on the \`cloudfront.net\` hostname and will block the script for those visitors. Acceptable to restore tracking for the ~80%+ who don't run such blockers — currently nobody is being tracked.

## Test plan
- [ ] After merge + deploy, visit a blog post on \`https://www.tigrisdata.com/blog/\` from a US IP in a regular Chrome window.
- [ ] DevTools console: \`document.cookie.split('; ').filter(c => c.includes('_reb2'))\` should return all 5 rb2b cookies within a few seconds.
- [ ] Navigate between blog posts → \`window.reb2b.collect()\` fires on each route change (existing client module keeps working).
- [ ] rb2b dashboard: identification volume should rise meaningfully over the next 24–48h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-code-change but affects client-side analytics loading by switching to a third-party CloudFront URL, which can be blocked by privacy tools and may impact tracking behavior in production.
> 
> **Overview**
> Switches the rb2b head-injected script (production, US/CA only) to load from `https://ddwl4m2hdecbv.cloudfront.net/...` instead of the `/_tigris/insights/...` proxied URL, restoring rb2b execution after upstream origin/hostname validation changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 277ebeb44c23ec3763c93df1c3a2b81f7f2e71e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->