### PR TITLE
fix(TweetEmbed): re-theme on color mode change and survive script load race

### DIFF
--- a/src/components/TweetEmbed/index.tsx
+++ b/src/components/TweetEmbed/index.tsx
@@ -16,7 +16,7 @@ interface TwitterWidgets {
         theme?: "light" | "dark";
         align?: string;
         conversation?: string;
-      },
+      }
     ) => Promise<HTMLElement | undefined>;
   };
   ready: (cb: (twttr: TwitterWidgets) => void) => void;

--- a/src/components/TweetEmbed/index.tsx
+++ b/src/components/TweetEmbed/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import { useColorMode } from "@docusaurus/theme-common";
 
@@ -62,7 +62,10 @@ function ensureTwitterScript(): void {
 
 function TweetEmbedInner({ url }: TweetEmbedProps) {
   const { colorMode } = useColorMode();
-  const containerRef = useRef<HTMLDivElement>(null);
+  // mountRef is owned exclusively by twttr — React renders no children into it,
+  // so we can mutate its contents freely without fighting React's DOM.
+  const mountRef = useRef<HTMLDivElement>(null);
+  const [rendered, setRendered] = useState(false);
   const id = tweetIdFromUrl(url);
 
   useEffect(() => {
@@ -74,19 +77,46 @@ function TweetEmbedInner({ url }: TweetEmbedProps) {
     ensureTwitterScript();
 
     window.twttr?.ready((twttr) => {
-      const container = containerRef.current;
-      if (cancelled || !container) {
+      const mount = mountRef.current;
+      if (cancelled || !mount) {
         return;
       }
 
-      // createTweet renders a fresh iframe, so clear any prior render (or the
-      // fallback link) first. This is what lets a colorMode toggle re-theme an
-      // already-rendered tweet.
-      container.replaceChildren();
-      twttr.widgets.createTweet(id, container, {
-        theme: colorMode === "dark" ? "dark" : "light",
-        align: "center",
-      });
+      twttr.widgets
+        .createTweet(id, mount, {
+          theme: colorMode === "dark" ? "dark" : "light",
+          align: "center",
+        })
+        .then((el) => {
+          // A newer run (theme toggle, tweet id change, or strict-mode
+          // remount) may have superseded this one while createTweet was in
+          // flight. Remove whatever this stale call injected and leave the DOM
+          // to the current run instead of clobbering it.
+          if (cancelled || mountRef.current !== mount) {
+            el?.remove();
+            return;
+          }
+
+          if (el) {
+            // Success: keep only the freshly rendered embed, dropping any stale
+            // embed left over from a previous theme.
+            mount.replaceChildren(el);
+            setRendered(true);
+          } else if (mount.childElementCount === 0) {
+            // Tweet is deleted, private, or blocked and nothing was rendered:
+            // keep the fallback "View tweet" link visible.
+            setRendered(false);
+          }
+        })
+        .catch(() => {
+          if (
+            !cancelled &&
+            mountRef.current === mount &&
+            mount.childElementCount === 0
+          ) {
+            setRendered(false);
+          }
+        });
     });
 
     return () => {
@@ -96,14 +126,14 @@ function TweetEmbedInner({ url }: TweetEmbedProps) {
 
   return (
     <div
-      ref={containerRef}
       style={{
         display: "flex",
         justifyContent: "center",
         margin: "1.5rem 0",
       }}
     >
-      <a href={url}>View tweet</a>
+      <div ref={mountRef} />
+      {!rendered && <a href={url}>View tweet</a>}
     </div>
   );
 }

--- a/src/components/TweetEmbed/index.tsx
+++ b/src/components/TweetEmbed/index.tsx
@@ -6,43 +6,93 @@ interface TweetEmbedProps {
   url: string;
 }
 
+interface TwitterWidgets {
+  widgets: {
+    load: (el?: HTMLElement) => void;
+    createTweet: (
+      id: string,
+      el: HTMLElement,
+      options?: {
+        theme?: "light" | "dark";
+        align?: string;
+        conversation?: string;
+      },
+    ) => Promise<HTMLElement | undefined>;
+  };
+  ready: (cb: (twttr: TwitterWidgets) => void) => void;
+  _e?: Array<(twttr: TwitterWidgets) => void>;
+}
+
 declare global {
   interface Window {
-    twttr?: {
-      widgets: {
-        load: (el?: HTMLElement) => void;
-      };
-    };
+    twttr?: TwitterWidgets;
   }
+}
+
+function tweetIdFromUrl(url: string): string | null {
+  const match = url.match(/status\/(\d+)/);
+  return match ? match[1] : null;
+}
+
+// Install the twttr.ready queue stub synchronously so callbacks registered
+// while widgets.js is still downloading fire once it loads. Mirrors Twitter's
+// official embed snippet.
+function ensureTwitterScript(): void {
+  if (window.twttr?.ready) {
+    return;
+  }
+
+  const twttr = (window.twttr ?? {}) as TwitterWidgets;
+  twttr._e = twttr._e ?? [];
+  twttr.ready = (cb) => {
+    twttr._e?.push(cb);
+  };
+  window.twttr = twttr;
+
+  if (document.getElementById("twitter-widgets-js")) {
+    return;
+  }
+
+  const script = document.createElement("script");
+  script.id = "twitter-widgets-js";
+  script.src = "https://platform.twitter.com/widgets.js";
+  script.async = true;
+  document.body.appendChild(script);
 }
 
 function TweetEmbedInner({ url }: TweetEmbedProps) {
   const { colorMode } = useColorMode();
   const containerRef = useRef<HTMLDivElement>(null);
+  const id = tweetIdFromUrl(url);
 
   useEffect(() => {
-    const loadWidget = () => {
-      if (window.twttr?.widgets && containerRef.current) {
-        window.twttr.widgets.load(containerRef.current);
+    if (!id) {
+      return;
+    }
+
+    let cancelled = false;
+    ensureTwitterScript();
+
+    window.twttr?.ready((twttr) => {
+      const container = containerRef.current;
+      if (cancelled || !container) {
+        return;
       }
+
+      // createTweet renders a fresh iframe, so clear any prior render (or the
+      // fallback link) first. This is what lets a colorMode toggle re-theme an
+      // already-rendered tweet.
+      container.replaceChildren();
+      twttr.widgets.createTweet(id, container, {
+        theme: colorMode === "dark" ? "dark" : "light",
+        align: "center",
+      });
+    });
+
+    return () => {
+      cancelled = true;
     };
-
-    if (window.twttr?.widgets) {
-      loadWidget();
-      return;
-    }
-
-    if (document.getElementById("twitter-widgets-js")) {
-      return;
-    }
-
-    const script = document.createElement("script");
-    script.id = "twitter-widgets-js";
-    script.src = "https://platform.twitter.com/widgets.js";
-    script.async = true;
-    script.onload = loadWidget;
-    document.body.appendChild(script);
-  }, [url, colorMode]);
+  }, [id, colorMode]);
 
   return (
     <div
@@ -53,12 +103,7 @@ function TweetEmbedInner({ url }: TweetEmbedProps) {
         margin: "1.5rem 0",
       }}
     >
-      <blockquote
-        className="twitter-tweet"
-        data-theme={colorMode === "dark" ? "dark" : "light"}
-      >
-        <a href={url}>View tweet</a>
-      </blockquote>
+      <a href={url}>View tweet</a>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

`src/components/TweetEmbed/index.tsx` embeds a tweet using Twitter's `widgets.js`. The original implementation rendered a static `<blockquote className="twitter-tweet">` and asked the widget library to upgrade it in place via `twttr.widgets.load()`. That model produced two defects (theme re-render no-op, script-load race), and the initial `createTweet` rewrite introduced two more (stale-promise injection, fallback loss on failure). All four are fixed here.

---

## Problem 1 — Color mode changes can't update an already-rendered tweet (Medium)

### Intent

The effect declared `colorMode` as a dependency so the tweet would re-theme when the user toggles the site's dark/light switch, and carried the theme on the blockquote:

```tsx
const loadWidget = () => {
  if (window.twttr?.widgets && containerRef.current) {
    window.twttr.widgets.load(containerRef.current);
  }
};
// ...
}, [url, colorMode]);

<blockquote className="twitter-tweet" data-theme={colorMode === "dark" ? "dark" : "light"}>
  <a href={url}>View tweet</a>
</blockquote>
```

### Why it fails

`widgets.js` is a one-way upgrade: on first render it **replaces** the `<blockquote>` with a rendered `<iframe>`. After that, `twttr.widgets.load(container)` only scans for *un-rendered* `.twitter-tweet` elements — the blockquote is gone, so the call is a **no-op**. The `data-theme` binding also does nothing, because React is updating an attribute on a blockquote that no longer exists in the DOM. The embed is frozen in whatever theme it first painted.

### Fix

Use `twttr.widgets.createTweet(id, mount, { theme })`, which renders a **fresh** iframe with an explicit theme. Each effect run re-creates the tweet with the current theme, so toggling dark/light genuinely re-themes the embed.

---

## Problem 2 — Tweet never renders while the script is still loading (Low)

### Why it fails

When `window.twttr` was not yet available but the script tag already existed (React strict-mode double-mount, or a second `TweetEmbed` on the page), the effect bailed without registering anything:

```tsx
if (window.twttr?.widgets) { loadWidget(); return; }   // not ready yet -> skip
if (document.getElementById("twitter-widgets-js")) return; // script exists -> dead end
// only the first instance reaches here and sets script.onload = loadWidget
```

Only the instance that *creates* the script gets an `onload` callback. Any instance running while the script is mid-flight returns with no callback, so when the script finishes nothing tells it to render — it stays stuck on the "View tweet" link.

### Fix

Install Twitter's official `twttr.ready()` queue stub **synchronously** in `ensureTwitterScript()`, before/independent of the script finishing. `ready()` pushes callbacks onto a `_e` array that `widgets.js` drains on load:

```tsx
const twttr = (window.twttr ?? {}) as TwitterWidgets;
twttr._e = twttr._e ?? [];
twttr.ready = (cb) => { twttr._e?.push(cb); };
window.twttr = twttr;
if (document.getElementById("twitter-widgets-js")) return; // don't double-inject
// ...append the <script> once
```

Every instance registers its render through `ready()`: if the script is loaded the callback fires immediately; if it's still downloading the callback is queued and fires on load. The `getElementById` guard now only prevents a duplicate `<script>` injection — it no longer drops the render.

---

## Problem 3 — Stale createTweet ignored cancellation (High)

### Why it fails

The first rewrite set a `cancelled` flag on cleanup, but only checked it **before** `createTweet` started. `createTweet` is async and was never awaited or re-checked on completion:

```tsx
window.twttr?.ready((twttr) => {
  if (cancelled || !container) return;       // checked once, up front
  container.replaceChildren();
  twttr.widgets.createTweet(id, container, { theme, align: "center" }); // fire-and-forget
});
```

So an older in-flight call (from a theme toggle, tweet-id change, or strict-mode remount) could still inject its iframe **after** a newer run had started — leaving the wrong theme, a duplicate embed, or the wrong tweet.

### Fix

Re-check cancellation inside the promise resolution and remove anything a superseded call injected:

```tsx
twttr.widgets.createTweet(id, mount, { theme, align: "center" }).then((el) => {
  if (cancelled || mountRef.current !== mount) {
    el?.remove();          // a newer run won — drop this stale iframe
    return;
  }
  if (el) {
    mount.replaceChildren(el);   // keep only the fresh embed; drop stale-theme iframe
    setRendered(true);
  }
  // ...failure handling below
});
```

Because React runs the previous effect's cleanup before the next effect, at most one run is ever un-cancelled, so only the current run mutates the visible DOM.

---

## Problem 4 — Fallback cleared on embed failure (Medium)

### Why it fails

`container.replaceChildren()` ran **before** `createTweet` resolved, removing the initial "View tweet" link. If `createTweet` resolved with no element (deleted, private, or blocked tweet), nothing repopulated the container — users saw an empty embed area with no link.

### Fix

Split the DOM into two siblings: a twttr-owned mount node React keeps childless, and a React-managed fallback link gated on a `rendered` state flag.

```tsx
<div /* centering flex container */>
  <div ref={mountRef} />               {/* twttr renders the iframe here */}
  {!rendered && <a href={url}>View tweet</a>}
</div>
```

- The fallback is **never imperatively removed** — it's React-managed and only hidden when `rendered` flips true on a successful embed, so React owns it cleanly (no `removeChild` errors on unmount).
- On a no-element resolution / rejection we `setRendered(false)` only when `mount.childElementCount === 0`, so a failed embed shows the link again instead of an empty box — without wiping a still-good embed from a previous successful render.
- The mount node carries no React children, so mutating its contents (`replaceChildren`, `el.remove()`) never races React's reconciliation.

---

## Supporting changes

- **Type declarations** — extracted a `TwitterWidgets` interface and extended `Window.twttr` with `widgets.createTweet` and `ready`/`_e`, keeping the existing `widgets.load`.
- **`tweetIdFromUrl` helper** — `createTweet` takes a status id, not a URL. Parses it with `/status\/(\d+)/`, covering both `twitter.com/.../status/<id>` and `x.com/.../status/<id>`; renders only the fallback link if no id is found.

## Trade-offs

`createTweet` rebuilds the iframe on each call, which is what makes live theme switching work — at the cost of a brief re-render flash when toggling. During a toggle the old (correct-theme) iframe stays visible until the new one resolves, so there's no empty gap.

## Verification

- `npx prettier --check` — clean.
- `npx eslint src/components/TweetEmbed/index.tsx` — clean.
- `npx tsc --noEmit` — no errors in `TweetEmbed` (remaining errors are pre-existing, in unrelated `blog/.../markdownChunk.js` files).
- `npm run build` — compiles successfully.

Browser-interactive checks (via `npm run start`, on the only current usage — `blog/2026-06-02-storage-sdk/index.mdx:52`):

1. Tweet renders (not just the fallback link).
2. Toggling the site dark/light switch re-themes the **already-rendered** tweet (Problem 1), with no duplicate/stale iframe (Problem 3).
3. Hard-reload on a throttled network confirms the tweet still renders once `widgets.js` finishes (Problem 2); strict-mode double-mount in dev exercises both the duplicate-script guard and the stale-cancellation path.
4. A bad tweet id / blocked embed keeps the "View tweet" link visible rather than an empty box (Problem 4).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated docs UI embed logic with no auth, data, or backend impact.
> 
> **Overview**
> **TweetEmbed** no longer uses a static `blockquote` plus `twttr.widgets.load()`. It now loads **widgets.js** via **`ensureTwitterScript()`** (with Twitter’s **`twttr.ready`** queue stub), parses the status id from the URL, and imperatively calls **`createTweet`** with a **`theme`** tied to Docusaurus **color mode**.
> 
> On **theme** or **id** changes, the effect clears the container and re-renders so dark/light updates apply to an already-shown iframe. A **cancelled** cleanup flag avoids stale **`ready`** callbacks during fast toggles. The visible fallback is a plain **“View tweet”** link until the iframe appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d945a6c821efbc7f89b9f6095c87de6edd8d2f3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
