### PR TITLE
chore(blog): feature objgit post on homepage

### DIFF
--- a/tigris.config.js
+++ b/tigris.config.js
@@ -14,8 +14,8 @@ module.exports = {
 
   // First entry is the main hero card; the rest are side cards.
   featuredPosts: [
+    "/objgit",
     "/storagesdk",
-    "/agent-shell-homepage",
     "/case-study-basic-memory",
     "/agent-shell-release",
   ],


### PR DESCRIPTION
## Summary

- Replace the agent shell homepage post with the objgit post in `featuredPosts`
- Promote `/objgit` to the hero card position (first entry)

## Notes

`/agent-shell-homepage` is removed from the featured list.

Assisted-by: Claude Opus 4.8 via Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only homepage content rotation with no auth, data, or application logic changes.
> 
> **Overview**
> Updates homepage blog promotion in `tigris.config.js` so **`/objgit`** is the **hero** (first `featuredPosts` entry) and **`/agent-shell-homepage`** is no longer featured.
> 
> The other side cards stay **`/storagesdk`**, **`/case-study-basic-memory`**, and **`/agent-shell-release`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4cd1ee9b818870c7c5258015744e4a7287ccfcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->