### PR TITLE
docs: point Tigris CLI links to storage monorepo

### DIFF
--- a/blog/2026-02-10-tigris-cli/index.mdx
+++ b/blog/2026-02-10-tigris-cli/index.mdx
@@ -136,15 +136,15 @@ out of any of these user-facing projects.
 When Abdullah was working on the CLI, he wanted to write a formal specification
 for the CLI and then transform that into the scaffolding for the code. This
 eventually evolved into
-[specs.yaml](https://github.com/tigrisdata/cli/blob/main/src/specs.yaml), which
-we parse with some custom code to generate the scaffolding required to wire
-everything up. This spec file ended up serving two purposes: it drove the RFC
-process by being the canonical source of truth for what the CLI should do, but
-it also was reused to generate the CLI itself. Change the spec, regenerate the
-CLI, everything updates and all is balanced as all things should be.
+[specs.yaml](https://github.com/tigrisdata/storage/blob/main/packages/cli/src/specs.yaml),
+which we parse with some custom code to generate the scaffolding required to
+wire everything up. This spec file ended up serving two purposes: it drove the
+RFC process by being the canonical source of truth for what the CLI should do,
+but it also was reused to generate the CLI itself. Change the spec, regenerate
+the CLI, everything updates and all is balanced as all things should be.
 
 As a neat side effect of this, here's
-[the implementation of the `objects put` command](https://github.com/tigrisdata/cli/blob/main/src/lib/objects/put.ts).
+[the implementation of the `objects put` command](https://github.com/tigrisdata/storage/blob/main/packages/cli/src/lib/objects/put.ts).
 It's in `src/lib/objects/put.ts` and directly maps to `objects put`. This gives
 us filesystem-based command routing the same way that Next.js gives you
 filesystem based web routing.
@@ -265,9 +265,10 @@ out the correct command from `--help` output.
 ## Conclusion
 
 Please try the CLI out! It's
-[open source on GitHub](https://github.com/tigrisdata/cli). We use it internally
-at Tigris. We plan to replace the AWS CLI with our CLI company-wide–there's only
-so many times you can type `aws s3api` before your fingers fall off.
+[open source on GitHub](https://github.com/tigrisdata/storage/tree/main/packages/cli).
+We use it internally at Tigris. We plan to replace the AWS CLI with our CLI
+company-wide–there's only so many times you can type `aws s3api` before your
+fingers fall off.
 
 Install our CLI with `npm`:
 
@@ -281,9 +282,9 @@ seconds.
 
 Try it out! Let us know what you think! We're still balancing familiarity with
 natural design, and real feedback beats internal speculation every time. Open
-[an issue on GitHub](https://github.com/tigrisdata/cli), stop by
-[our Discord](https://community.tigrisdata.com) or reply wherever you found this
-post.
+[an issue on GitHub](https://github.com/tigrisdata/storage/tree/main/packages/cli),
+stop by [our Discord](https://community.tigrisdata.com) or reply wherever you
+found this post.
 
 The shell is waiting.
 
@@ -291,5 +292,5 @@ The shell is waiting.
   title="Ready to control Tigris from your terminal?"
   subtitle="Install the Tigris CLI with npm and manage your object storage without leaving the command line."
   button="Get the CLI"
-  link="https://github.com/tigrisdata/cli"
+  link="https://github.com/tigrisdata/storage/tree/main/packages/cli"
 />


### PR DESCRIPTION
## Summary

The `@tigrisdata/cli` source moved from the standalone `tigrisdata/cli` repo (now being archived) into the `tigrisdata/storage` monorepo at `packages/cli`. `@tigrisdata/agent-shell` likewise moved into the same monorepo at `packages/agent-shell`. This updates the blog to point at the new canonical locations.

## Changes

`blog/2026-02-10-tigris-cli/index.mdx` — updated 5 GitHub links that pointed at the archived `tigrisdata/cli` repo:

- `specs.yaml` blob link → `github.com/tigrisdata/storage/blob/main/packages/cli/src/specs.yaml`
- `objects put` implementation blob link → `github.com/tigrisdata/storage/blob/main/packages/cli/src/lib/objects/put.ts`
- "open source on GitHub" repo link → `github.com/tigrisdata/storage/tree/main/packages/cli`
- "an issue on GitHub" repo link → `github.com/tigrisdata/storage/tree/main/packages/cli`
- InlineCta `link` → `github.com/tigrisdata/storage/tree/main/packages/cli`

(Prettier re-wrapped the surrounding prose per the repo's `proseWrap: always` setting.)

## Intentionally left unchanged

- All `npm install -g @tigrisdata/cli`, `npx @tigrisdata/agent-shell`, `@tigrisdata/agent-shell` npm-package links, and code imports — package names did not change.
- `github.com/tigrisdata/cli/pull/22` in `blog/2026-02-26-using-bun-and-benchmark/index.mdx` — a historical PR permalink that "tells the full story"; archived repos retain their PRs and there is no equivalent in the monorepo, so pointing it at the package tree would break the reference.
- No `github.com/tigrisdata/agent-shell` repo links exist in the blog — all agent-shell references are npm/npx/docs links, so nothing needed changing there.

No hardcoded CLI install one-liners (`releases/latest/download/install.sh`/`.ps1`) were found in the blog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link updates with no runtime, auth, or data-handling changes.
> 
> **Overview**
> Updates the **Tigris CLI** blog post so GitHub URLs match the CLI living in **`tigrisdata/storage`** at **`packages/cli`** instead of the archived **`tigrisdata/cli`** repo.
> 
> **Five links** now target the monorepo: **`specs.yaml`**, the **`objects put`** source file, open-source / issue CTAs, and the **`InlineCta`** button. **`npm install -g @tigrisdata/cli`** and other npm references are unchanged. Surrounding sentences were re-wrapped by Prettier only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fc9a5af446a853a861887e06609255e2508a36c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->